### PR TITLE
Fix Azure portal URLs and remove app registration flag

### DIFF
--- a/app/actions/execution-actions.ts
+++ b/app/actions/execution-actions.ts
@@ -534,9 +534,7 @@ export async function executeM1CreateProvisioningApp(
         );
         if (existingApp.id && sp?.id) {
           const resourceUrl =
-            process.env.SHOW_APP_REGISTRATIONS === "true"
-              ? `https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/appId/${existingApp.appId}/isMSAApp~/false`
-              : `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Overview/appId/${existingApp.appId}/objectId/${sp.id}`;
+            `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Overview/appId/${existingApp.appId}/objectId/${sp.id}`;
           return {
             success: true,
             message: `Enterprise app '${appName}' for provisioning already exists.`,
@@ -558,9 +556,7 @@ export async function executeM1CreateProvisioningApp(
       success: true,
       message: `Enterprise app '${appName}' created.`,
       resourceUrl:
-        process.env.SHOW_APP_REGISTRATIONS === "true"
-          ? `https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/appId/${result.application.appId}/isMSAApp~/false`
-          : `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Overview/appId/${result.application.appId}/objectId/${result.servicePrincipal.id}`,
+        `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Overview/appId/${result.application.appId}/objectId/${result.servicePrincipal.id}`,
       outputs: {
         [OUTPUT_KEYS.PROVISIONING_APP_ID]: result.application.appId,
         [OUTPUT_KEYS.PROVISIONING_APP_OBJECT_ID]: result.application.id,
@@ -601,9 +597,7 @@ export async function executeM2ConfigureProvisioningAppProperties(
       accountEnabled: true,
     });
     const resourceUrl =
-      process.env.SHOW_APP_REGISTRATIONS === "true"
-        ? `https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/appId/${appId}/isMSAApp~/false`
-        : `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Overview/appId/${appId}/objectId/${spObjectId}`;
+      `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Overview/servicePrincipalId/${spObjectId}/appId/${appId}`;
     return {
       success: true,
       message: "Provisioning app service principal enabled.",
@@ -891,9 +885,7 @@ export async function executeM6CreateSamlSsoApp(
         );
         if (existingApp.id && sp?.id) {
           const resourceUrl =
-            process.env.SHOW_APP_REGISTRATIONS === "true"
-              ? `https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/appId/${existingApp.appId}/isMSAApp~/false`
-              : `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Overview/appId/${existingApp.appId}/objectId/${sp.id}`;
+            `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Overview/appId/${existingApp.appId}/objectId/${sp.id}`;
           return {
             success: true,
             message: `Enterprise app '${appName}' for SAML SSO already exists.`,
@@ -915,9 +907,7 @@ export async function executeM6CreateSamlSsoApp(
       success: true,
       message: `Enterprise app '${appName}' for SAML SSO created.`,
       resourceUrl:
-        process.env.SHOW_APP_REGISTRATIONS === "true"
-          ? `https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/appId/${result.application.appId}/isMSAApp~/false`
-          : `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Overview/appId/${result.application.appId}/objectId/${result.servicePrincipal.id}`,
+        `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Overview/appId/${result.application.appId}/objectId/${result.servicePrincipal.id}`,
       outputs: {
         [OUTPUT_KEYS.SAML_SSO_APP_ID]: result.application.appId,
         [OUTPUT_KEYS.SAML_SSO_APP_OBJECT_ID]: result.application.id,

--- a/lib/steps.ts
+++ b/lib/steps.ts
@@ -217,17 +217,16 @@ export const allStepDefinitions: StepDefinition[] = [
       executeM1CreateProvisioningApp(context),
     adminUrls: {
       configure: (outputs) => {
+        const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
         const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
-        if (!appId)
-          return "https://portal.azure.com/#view/Microsoft_AAD_IAM/StartboardApplicationsMenuBlade/~/AppAppsPreview";
-        return `https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/appId/${appId}/isMSAApp~/false`;
+        if (!spId || !appId) return null;
+        return `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Overview/servicePrincipalId/${spId}/appId/${appId}`;
       },
       verify: (outputs) => {
         const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
         const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
-        return spId
-          ? `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Overview/servicePrincipalId/${spId}/appId/${appId || ""}`
-          : null;
+        if (!spId || !appId) return null;
+        return `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Overview/servicePrincipalId/${spId}/appId/${appId}`;
       },
     },
   },
@@ -255,16 +254,16 @@ export const allStepDefinitions: StepDefinition[] = [
       executeM2ConfigureProvisioningAppProperties(context),
     adminUrls: {
       configure: (outputs) => {
+        const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
         const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
-        if (!appId) return null;
-        return `https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/appId/${appId}/isMSAApp~/false`;
+        if (!spId || !appId) return null;
+        return `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Overview/servicePrincipalId/${spId}/appId/${appId}`;
       },
       verify: (outputs) => {
         const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
         const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
-        return spId
-          ? `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Overview/servicePrincipalId/${spId}/appId/${appId || ""}`
-          : null;
+        if (!spId || !appId) return null;
+        return `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Overview/servicePrincipalId/${spId}/appId/${appId}`;
       },
     },
   },
@@ -311,16 +310,18 @@ export const allStepDefinitions: StepDefinition[] = [
       return executeM3AuthorizeProvisioningConnection(context);
     },
     adminUrls: {
-      configure: (outputs) =>
-        outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID] &&
-        outputs[OUTPUT_KEYS.PROVISIONING_APP_ID]
-          ? `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/ProvisioningManagement/appId/${outputs[OUTPUT_KEYS.PROVISIONING_APP_ID]}/objectId/${outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID]}`
-          : null,
-      verify: (outputs) =>
-        outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID] &&
-        outputs[OUTPUT_KEYS.PROVISIONING_APP_ID]
-          ? `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/ProvisioningManagement/appId/${outputs[OUTPUT_KEYS.PROVISIONING_APP_ID]}/objectId/${outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID]}`
-          : null,
+      configure: (outputs) => {
+        const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
+        const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
+        if (!spId || !appId) return null;
+        return `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/ProvisioningManagement/appId/${appId}/objectId/${spId}`;
+      },
+      verify: (outputs) => {
+        const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
+        const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
+        if (!spId || !appId) return null;
+        return `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/ProvisioningManagement/appId/${appId}/objectId/${spId}`;
+      },
     },
   },
   {
@@ -348,16 +349,18 @@ export const allStepDefinitions: StepDefinition[] = [
     execute: (context: StepContext): Promise<StepExecutionResult> =>
       executeM4ConfigureProvisioningAttributeMappings(context),
     adminUrls: {
-      configure: (outputs) =>
-        outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID] &&
-        outputs[OUTPUT_KEYS.PROVISIONING_APP_ID]
-          ? `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/ProvisioningManagement/appId/${outputs[OUTPUT_KEYS.PROVISIONING_APP_ID]}/objectId/${outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID]}`
-          : null,
-      verify: (outputs) =>
-        outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID] &&
-        outputs[OUTPUT_KEYS.PROVISIONING_APP_ID]
-          ? `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/ProvisioningManagement/appId/${outputs[OUTPUT_KEYS.PROVISIONING_APP_ID]}/objectId/${outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID]}`
-          : null,
+      configure: (outputs) => {
+        const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
+        const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
+        if (!spId || !appId) return null;
+        return `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/ProvisioningManagement/appId/${appId}/objectId/${spId}`;
+      },
+      verify: (outputs) => {
+        const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
+        const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
+        if (!spId || !appId) return null;
+        return `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/ProvisioningManagement/appId/${appId}/objectId/${spId}`;
+      },
     },
   },
   {
@@ -408,16 +411,18 @@ export const allStepDefinitions: StepDefinition[] = [
       return result;
     },
     adminUrls: {
-      configure: (outputs) =>
-        outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID] &&
-        outputs[OUTPUT_KEYS.PROVISIONING_APP_ID]
-          ? `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/ProvisioningManagement/appId/${outputs[OUTPUT_KEYS.PROVISIONING_APP_ID]}/objectId/${outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID]}`
-          : null,
-      verify: (outputs) =>
-        outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID] &&
-        outputs[OUTPUT_KEYS.PROVISIONING_APP_ID]
-          ? `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/ProvisioningManagement/appId/${outputs[OUTPUT_KEYS.PROVISIONING_APP_ID]}/objectId/${outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID]}`
-          : null,
+      configure: (outputs) => {
+        const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
+        const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
+        if (!spId || !appId) return null;
+        return `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/ProvisioningManagement/appId/${appId}/objectId/${spId}`;
+      },
+      verify: (outputs) => {
+        const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
+        const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
+        if (!spId || !appId) return null;
+        return `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/ProvisioningManagement/appId/${appId}/objectId/${spId}`;
+      },
     },
   },
 
@@ -446,16 +451,16 @@ export const allStepDefinitions: StepDefinition[] = [
       executeM6CreateSamlSsoApp(context),
     adminUrls: {
       configure: (outputs) => {
+        const spId = outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID];
         const appId = outputs[OUTPUT_KEYS.SAML_SSO_APP_ID];
-        if (!appId) return null;
-        return `https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/appId/${appId}/isMSAApp~/false`;
+        if (!spId || !appId) return null;
+        return `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Overview/servicePrincipalId/${spId}/appId/${appId}`;
       },
       verify: (outputs) => {
         const spId = outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID];
         const appId = outputs[OUTPUT_KEYS.SAML_SSO_APP_ID];
-        return spId
-          ? `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Overview/servicePrincipalId/${spId}/appId/${appId || ""}`
-          : null;
+        if (!spId || !appId) return null;
+        return `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Overview/servicePrincipalId/${spId}/appId/${appId}`;
       },
     },
   },
@@ -494,16 +499,16 @@ export const allStepDefinitions: StepDefinition[] = [
       executeM7ConfigureAzureSamlAppSettings(context),
     adminUrls: {
       configure: (outputs) => {
+        const spId = outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID];
         const appId = outputs[OUTPUT_KEYS.SAML_SSO_APP_ID];
-        if (!appId) return null;
-        return `https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/appId/${appId}/isMSAApp~/false`;
+        if (!spId || !appId) return null;
+        return `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/SingleSignOn/appId/${appId}/objectId/${spId}`;
       },
       verify: (outputs) => {
         const spId = outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID];
         const appId = outputs[OUTPUT_KEYS.SAML_SSO_APP_ID];
-        return spId
-          ? `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Overview/servicePrincipalId/${spId}/appId/${appId || ""}`
-          : null;
+        if (!spId || !appId) return null;
+        return `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/SingleSignOn/appId/${appId}/objectId/${spId}`;
       },
     },
   },
@@ -534,16 +539,16 @@ export const allStepDefinitions: StepDefinition[] = [
       executeM8RetrieveAzureIdpMetadata(context),
     adminUrls: {
       configure: (outputs) => {
+        const spId = outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID];
         const appId = outputs[OUTPUT_KEYS.SAML_SSO_APP_ID];
-        if (!appId) return null;
-        return `https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/appId/${appId}/isMSAApp~/false`;
+        if (!spId || !appId) return null;
+        return `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/SingleSignOn/appId/${appId}/objectId/${spId}`;
       },
       verify: (outputs) => {
         const spId = outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID];
         const appId = outputs[OUTPUT_KEYS.SAML_SSO_APP_ID];
-        return spId
-          ? `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Overview/servicePrincipalId/${spId}/appId/${appId || ""}`
-          : null;
+        if (!spId || !appId) return null;
+        return `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/SingleSignOn/appId/${appId}/objectId/${spId}`;
       },
     },
   },
@@ -703,16 +708,18 @@ export const allStepDefinitions: StepDefinition[] = [
     execute: (context: StepContext): Promise<StepExecutionResult> =>
       executeM9AssignUsersToAzureSsoApp(context),
     adminUrls: {
-      configure: (outputs) =>
-        outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID] &&
-        outputs[OUTPUT_KEYS.SAML_SSO_APP_ID]
-          ? `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/UsersAndGroups/servicePrincipalId/${outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID]}/appId/${outputs[OUTPUT_KEYS.SAML_SSO_APP_ID]}`
-          : null,
-      verify: (outputs) =>
-        outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID] &&
-        outputs[OUTPUT_KEYS.SAML_SSO_APP_ID]
-          ? `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/UsersAndGroups/servicePrincipalId/${outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID]}/appId/${outputs[OUTPUT_KEYS.SAML_SSO_APP_ID]}`
-          : null,
+      configure: (outputs) => {
+        const spId = outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID];
+        const appId = outputs[OUTPUT_KEYS.SAML_SSO_APP_ID];
+        if (!spId || !appId) return null;
+        return `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/UsersAndGroups/servicePrincipalId/${spId}/appId/${appId}`;
+      },
+      verify: (outputs) => {
+        const spId = outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID];
+        const appId = outputs[OUTPUT_KEYS.SAML_SSO_APP_ID];
+        if (!spId || !appId) return null;
+        return `https://portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/UsersAndGroups/servicePrincipalId/${spId}/appId/${appId}`;
+      },
     },
   },
 


### PR DESCRIPTION
## Summary
- remove `SHOW_APP_REGISTRATIONS` logic from execution actions
- point all Microsoft admin URLs to Enterprise Application blades

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683f462d11b48322805ea7e741349cf3