### PR TITLE
Handle auth errors in automation

### DIFF
--- a/app/actions/check-actions.ts
+++ b/app/actions/check-actions.ts
@@ -4,7 +4,7 @@ import { auth } from "@/app/(auth)/auth";
 import * as google from "@/lib/api/google";
 import * as microsoft from "@/lib/api/microsoft";
 import { APIError } from "@/lib/api/utils";
-import { AuthenticationError } from "@/lib/api/auth-interceptor";
+import { AuthenticationError, isAuthenticationError } from "@/lib/api/auth-interceptor";
 import type { StepCheckResult } from "@/lib/types";
 import type { Session } from "next-auth";
 import { OUTPUT_KEYS } from "@/lib/types";
@@ -55,6 +55,19 @@ function handleCheckError(
   defaultMessage: string,
 ): StepCheckResult {
   console.error(`Check Action Error - ${defaultMessage}:`, error);
+
+  // Special handling for auth errors
+  if (isAuthenticationError(error)) {
+    return {
+      completed: false,
+      message: error.message,
+      outputs: {
+        errorCode: "AUTH_EXPIRED",
+        errorProvider: error.provider,
+      },
+    };
+  }
+
   const message = error instanceof Error ? error.message : defaultMessage;
   return { completed: false, message };
 }

--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -267,7 +267,11 @@ export function AutomationDashboard({
             updateStep({
               id: stepId,
               status: "failed",
-              error: "Authentication expired. Please sign in again.",
+              error: err.message,
+              metadata: {
+                errorCode: "AUTH_EXPIRED",
+                errorProvider: err.provider,
+              },
             }),
           );
           return;

--- a/components/step.tsx
+++ b/components/step.tsx
@@ -55,12 +55,20 @@ export function StepItem({
   const outputs = useAppSelector((state) => state.appConfig.outputs);
 
   const prerequisitesMet = React.useMemo(() => {
+    // Auth errors override prerequisite logic to allow retrying the step
+    if (
+      step.error?.includes("AUTH_EXPIRED") ||
+      step.error?.includes("authentication expired")
+    ) {
+      return true;
+    }
+
     return (
       step.requires?.every(
         (reqId) => allStepsStatus[reqId]?.status === "completed",
       ) ?? true
     );
-  }, [step.requires, allStepsStatus]);
+  }, [step.requires, step.error, allStepsStatus]);
 
   const getStatusVisuals = () => {
     switch (step.status) {
@@ -111,17 +119,20 @@ export function StepItem({
     );
   };
 
-  const isStepEffectivelyDisabled = !canRunGlobal || !prerequisitesMet;
+  const isStepEffectivelyDisabled =
+    !canRunGlobal || (!prerequisitesMet && !step.error?.includes("AUTH_EXPIRED"));
+
   const runButtonDisabledReason = !canRunGlobal
     ? "Global prerequisites (auth/config) not met."
-    : !prerequisitesMet
+    : !prerequisitesMet && !step.error?.includes("AUTH_EXPIRED")
       ? "Prerequisite steps not completed."
       : undefined;
 
   const allowRetryForAutomated =
     step.automatable &&
     (step.status === "failed" ||
-      (step.status === "completed" && step.metadata?.preExisting === true));
+      (step.status === "completed" && step.metadata?.preExisting === true) ||
+      step.metadata?.errorCode === "AUTH_EXPIRED");
 
   return (
     <li className="flex gap-x-3">
@@ -268,6 +279,17 @@ export function StepItem({
                 </p>
               )}
             </div>
+          )}
+
+          {step.status === "failed" && step.metadata?.errorCode === "AUTH_EXPIRED" && (
+            <Alert variant="destructive" className="mt-2">
+              <AlertCircleIcon className="h-4 w-4" />
+              <AlertTitle>Authentication Required</AlertTitle>
+              <AlertDescription>
+                Your {step.metadata.errorProvider === "google" ? "Google Workspace" : "Microsoft"}
+                {" "}session has expired. Please sign in again to continue.
+              </AlertDescription>
+            </Alert>
           )}
 
           {step.status === "failed" && step.error && (

--- a/hooks/use-auto-check.ts
+++ b/hooks/use-auto-check.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { useAppSelector } from "./use-redux";
+import { useSessionSync } from "./use-session-sync";
 
 /**
  * Runs lightweight "check" functions for a subset of steps once the
@@ -11,9 +12,17 @@ export function useAutoCheck(executeCheck: (stepId: string) => Promise<void>) {
   const appConfig = useAppSelector((state) => state.appConfig);
   const stepsStatus = useAppSelector((state) => state.setupSteps.steps);
   const hasChecked = useRef(false);
+  const { session } = useSessionSync();
 
   useEffect(() => {
-    if (!appConfig.domain || !appConfig.tenantId || hasChecked.current) return;
+    if (
+      !session?.hasGoogleAuth ||
+      !session?.hasMicrosoftAuth ||
+      !appConfig.domain ||
+      !appConfig.tenantId ||
+      hasChecked.current
+    )
+      return;
 
     hasChecked.current = true;
     // Only run checks for steps that perform safe, read-only operations.
@@ -37,5 +46,5 @@ export function useAutoCheck(executeCheck: (stepId: string) => Promise<void>) {
       .map((id) => executeCheck(id));
 
     Promise.all(checkPromises).catch(console.error);
-  }, [appConfig.domain, appConfig.tenantId, stepsStatus, executeCheck]);
+  }, [appConfig.domain, appConfig.tenantId, stepsStatus, executeCheck, session]);
 }


### PR DESCRIPTION
## Summary
- allow retry when auth errors occur in step
- show specific auth expired alerts in steps
- propagate auth error metadata in dashboard and server actions
- block auto-check when missing authentication

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_683f6383b85c8322acba9c7aacc2573e