### PR TITLE
Handle auth errors in automation

### DIFF
--- a/app/actions/check-actions.ts
+++ b/app/actions/check-actions.ts
@@ -4,7 +4,7 @@ import { auth } from "@/app/(auth)/auth";
 import * as google from "@/lib/api/google";
 import * as microsoft from "@/lib/api/microsoft";
 import { APIError } from "@/lib/api/utils";
-import { AuthenticationError } from "@/lib/api/auth-interceptor";
+import { AuthenticationError, isAuthenticationError } from "@/lib/api/auth-interceptor";
 import type { StepCheckResult } from "@/lib/types";
 import type { Session } from "next-auth";
 import { OUTPUT_KEYS } from "@/lib/types";
@@ -55,6 +55,19 @@ function handleCheckError(
   defaultMessage: string,
 ): StepCheckResult {
   console.error(`Check Action Error - ${defaultMessage}:`, error);
+
+  // Special handling for auth errors
+  if (isAuthenticationError(error)) {
+    return {
+      completed: false,
+      message: error.message,
+      outputs: {
+        errorCode: "AUTH_EXPIRED",
+        errorProvider: error.provider,
+      },
+    };
+  }
+
   const message = error instanceof Error ? error.message : defaultMessage;
   return { completed: false, message };
 }


### PR DESCRIPTION
## Summary
- allow retry when auth errors occur in step
- show specific auth expired alerts in steps
- propagate auth error metadata in dashboard and server actions
- block auto-check when missing authentication
- fix auto-check error handling for auth failures

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_683f6383b85c8322acba9c7aacc2573e