### PR TITLE
Fix step prerequisites and session validation

### DIFF
--- a/lib/api/session-validator.ts
+++ b/lib/api/session-validator.ts
@@ -1,0 +1,96 @@
+import { auth } from "@/app/(auth)/auth";
+
+export interface SessionValidation {
+  valid: boolean;
+  googleValid: boolean;
+  microsoftValid: boolean;
+  error?: {
+    provider: "google" | "microsoft" | "both";
+    message: string;
+    code?: string;
+  };
+}
+
+export async function validateSessionTokens(): Promise<SessionValidation> {
+  try {
+    const session = await auth();
+
+    if (!session) {
+      return {
+        valid: false,
+        googleValid: false,
+        microsoftValid: false,
+        error: {
+          provider: "both",
+          message: "No session found",
+        },
+      };
+    }
+
+    // Check for explicit refresh token errors
+    if (session.error === "RefreshTokenError") {
+      const missingProvider = !session.googleToken
+        ? !session.microsoftToken
+          ? "both"
+          : "google"
+        : "microsoft";
+
+      return {
+        valid: false,
+        googleValid: !!session.googleToken,
+        microsoftValid: !!session.microsoftToken,
+        error: {
+          provider: missingProvider,
+          message: "Session expired - refresh failed",
+          code: "REFRESH_TOKEN_ERROR",
+        },
+      };
+    }
+
+    // Validate individual tokens
+    const googleValid = !!session.googleToken && session.hasGoogleAuth;
+    const microsoftValid = !!session.microsoftToken && session.hasMicrosoftAuth;
+
+    if (!googleValid || !microsoftValid) {
+      const missingProvider = !googleValid
+        ? !microsoftValid
+          ? "both"
+          : "google"
+        : "microsoft";
+
+      return {
+        valid: false,
+        googleValid,
+        microsoftValid,
+        error: {
+          provider: missingProvider,
+          message:
+            missingProvider === "both"
+              ? "Both providers authentication required"
+              : missingProvider === "google"
+                ? "Google Workspace authentication required"
+                : "Microsoft authentication required",
+          code: "AUTH_MISSING",
+        },
+      };
+    }
+
+    return {
+      valid: true,
+      googleValid: true,
+      microsoftValid: true,
+    };
+  } catch (error) {
+    console.error("Session validation error:", error);
+    return {
+      valid: false,
+      googleValid: false,
+      microsoftValid: false,
+      error: {
+        provider: "both",
+        message: "Failed to validate session",
+        code: "VALIDATION_ERROR",
+      },
+    };
+  }
+}

--- a/lib/steps.ts
+++ b/lib/steps.ts
@@ -53,7 +53,7 @@ export const allStepDefinitions: StepDefinition[] = [
       "Creates an Organizational Unit (OU) named 'Automation' in Google Workspace. This can be useful for applying specific settings or housing accounts related to automated processes, although this tool primarily operates using the logged-in administrator's permissions.",
     category: "Google",
     automatable: true,
-    requires: ["G-3"],
+    requires: [],
     check: (_context: StepContext): Promise<StepCheckResult> =>
       checkOrgUnitExists("/Automation"),
     execute: (context: StepContext): Promise<StepExecutionResult> =>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -22,3 +22,27 @@ export function validateRequiredOutputs(
   const missing = required.filter((k) => !outputs[k]);
   return { valid: missing.length === 0, missing };
 }
+
+/**
+ * Creates a debounced function that delays invoking func until after wait milliseconds
+ * have elapsed since the last time the debounced function was invoked.
+ */
+export function debounce<T extends (...args: unknown[]) => unknown>(
+  func: T,
+  wait: number,
+): (...args: Parameters<T>) => void {
+  let timeout: NodeJS.Timeout | null = null;
+
+  return function executedFunction(...args: Parameters<T>) {
+    const later = () => {
+      timeout = null;
+      func(...args);
+    };
+
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+
+    timeout = setTimeout(later, wait);
+  };
+}


### PR DESCRIPTION
## Summary
- break circular dependency for step G-1
- improve prerequisite and button logic in StepItem UI
- add session token validation helper
- debounce auto-checks with session validation
- add debounce utility
- enhance authentication error detection

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_683f694407708322b47cf393ab69b22a