### PR TITLE
Improve auth error handling

### DIFF
--- a/app/actions/execution-actions.ts
+++ b/app/actions/execution-actions.ts
@@ -47,6 +47,10 @@ async function handleExecutionError(
         message: error.message,
         code: "AUTH_EXPIRED",
       },
+      outputs: {
+        errorCode: "AUTH_EXPIRED",
+        errorProvider: error.provider,
+      },
     };
   }
   if (error instanceof APIError) {

--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -196,6 +196,10 @@ export function AutomationDashboard({
               status: "failed",
               error: result.error?.message ?? "Unknown error during execution.",
               message: result.message,
+              metadata: {
+                ...(result.outputs || {}),
+                resourceUrl: result.resourceUrl,
+              },
             }),
           );
           toast.error(`${definition.title}: ${result.error?.message ?? "Failed"}`, {
@@ -217,6 +221,10 @@ export function AutomationDashboard({
               id: stepId,
               status: "failed",
               error: "Authentication expired. Please sign in again.",
+              metadata: {
+                errorCode: "AUTH_EXPIRED",
+                errorProvider: err.provider,
+              },
             }),
           );
           return;


### PR DESCRIPTION
## Summary
- expose auth errors from server actions as step metadata
- surface authentication expiry in dashboard state updates

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_683f755c7c1083229f597b0fbac0fcda