### PR TITLE
Fix error bubbling

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 
 import "./globals.css";
 import { Providers } from "./providers";
+import { ErrorToastProvider } from "@/components/error-toast-provider";
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertTriangleIcon } from "lucide-react";
@@ -52,8 +53,10 @@ export default function RootLayout({
           </AlertDescription>
         </Alert>
         <Providers>
-          {children}
-          <Toaster richColors />
+          <ErrorToastProvider>
+            {children}
+            <Toaster richColors />
+          </ErrorToastProvider>
         </Providers>
       </body>
     </html>

--- a/components/error-toast-provider.tsx
+++ b/components/error-toast-provider.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect } from "react";
+import { toast } from "sonner";
+
+export function ErrorToastProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  useEffect(() => {
+    const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
+      console.error("Unhandled promise rejection:", event.reason);
+
+      if (
+        event.reason?.message?.includes("API") &&
+        event.reason?.message?.includes("not enabled")
+      ) {
+        toast.error("Google Cloud API not enabled", {
+          description: "Check the console for details on which API to enable",
+          duration: 10000,
+        });
+      }
+    };
+
+    window.addEventListener("unhandledrejection", handleUnhandledRejection);
+    return () => {
+      window.removeEventListener(
+        "unhandledrejection",
+        handleUnhandledRejection,
+      );
+    };
+  }, []);
+
+  return <>{children}</>;
+}

--- a/components/step.tsx
+++ b/components/step.tsx
@@ -207,7 +207,7 @@ export function StepItem({
                         <a
                           href={
                             typeof step.adminUrls.configure === "function"
-                              ? step.adminUrls.configure(outputs) ?? "#"
+                              ? (step.adminUrls.configure(outputs) ?? "#")
                               : step.adminUrls.configure
                           }
                           target="_blank"
@@ -278,7 +278,8 @@ export function StepItem({
                         disabled={
                           isStepEffectivelyDisabled ||
                           step.status === "in_progress" ||
-                          (step.status === ("completed" as StepStatusInfo["status"]) &&
+                          (step.status ===
+                            ("completed" as StepStatusInfo["status"]) &&
                             !step.metadata?.preExisting)
                         }
                         variant={
@@ -343,25 +344,61 @@ export function StepItem({
             </div>
           )}
 
-          {step.status === "failed" && step.metadata?.errorCode === "AUTH_EXPIRED" && (
-            <Alert variant="destructive" className="mt-2">
-              <AlertCircleIcon className="h-4 w-4" />
-              <AlertTitle>Authentication Required</AlertTitle>
-              <AlertDescription>
-                Your {step.metadata.errorProvider === "google" ? "Google Workspace" : "Microsoft"}
-                {" "}session has expired. Please sign in again to continue.
-              </AlertDescription>
-            </Alert>
-          )}
+          {step.status === "failed" &&
+            step.metadata?.errorCode === "AUTH_EXPIRED" && (
+              <Alert variant="destructive" className="mt-2">
+                <AlertCircleIcon className="h-4 w-4" />
+                <AlertTitle>Authentication Required</AlertTitle>
+                <AlertDescription>
+                  Your{" "}
+                  {step.metadata.errorProvider === "google"
+                    ? "Google Workspace"
+                    : "Microsoft"}{" "}
+                  session has expired. Please sign in again to continue.
+                </AlertDescription>
+              </Alert>
+            )}
 
           {step.status === "failed" && step.error && (
             <Alert variant="destructive" className="mt-2 text-xs">
               <AlertCircleIcon className="h-4 w-4" />
               <AlertTitle className="font-medium">Error</AlertTitle>
               <AlertDescription>
-                {step.error.includes(
-                  "is not enabled for your Google Cloud project",
-                ) ? (
+                {step.metadata?.errorCode === "API_NOT_ENABLED" ? (
+                  <div className="space-y-2">
+                    <p>This step requires enabling a Google Cloud API:</p>
+                    <div className="text-xs bg-red-50 dark:bg-red-950 p-2 rounded space-y-1">
+                      {step.error.split("\n").map((line, i) => {
+                        const urlMatch = line.match(
+                          /https:\/\/console\.developers\.google\.com[^\s]+/,
+                        );
+                        if (urlMatch) {
+                          const parts = line.split(urlMatch[0]);
+                          return (
+                            <div key={i}>
+                              {parts[0]}
+                              <a
+                                href={urlMatch[0]}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="underline text-blue-600 hover:text-blue-800 font-medium"
+                              >
+                                Enable API
+                              </a>
+                              {parts[1]}
+                            </div>
+                          );
+                        }
+                        return <div key={i}>{line}</div>;
+                      })}
+                    </div>
+                    <p className="text-xs italic">
+                      After enabling, wait 2-3 minutes before retrying.
+                    </p>
+                  </div>
+                ) : step.error.includes(
+                    "is not enabled for your Google Cloud project",
+                  ) ? (
                   <div className="space-y-2">
                     <p>This step requires enabling a Google Cloud API:</p>
                     <div className="text-xs bg-red-50 dark:bg-red-950 p-2 rounded">


### PR DESCRIPTION
## Summary
- return detailed failure info from check actions
- surface check errors in Dashboard with toasts
- show API enablement messages with links
- add global error toast provider

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_683f8302d9988322a7a94d236c826b60