### PR TITLE
Streamline provisioning steps

### DIFF
--- a/components/google-token-modal.tsx
+++ b/components/google-token-modal.tsx
@@ -20,7 +20,7 @@ import {
   ExternalLinkIcon,
   InfoIcon,
 } from "lucide-react";
-import { useAppDispatch } from "@/hooks/use-redux";
+import { useAppDispatch, useAppSelector } from "@/hooks/use-redux";
 import { addOutput } from "@/lib/redux/slices/app-config";
 import { OUTPUT_KEYS } from "@/lib/types";
 import { toast } from "sonner";
@@ -37,6 +37,7 @@ export function GoogleTokenModal({
   onComplete,
 }: GoogleTokenModalProps) {
   const dispatch = useAppDispatch();
+  const outputs = useAppSelector((state) => state.appConfig.outputs);
   const [token, setToken] = useState("");
   const [isValidating, setIsValidating] = useState(false);
 
@@ -67,13 +68,12 @@ export function GoogleTokenModal({
 
   const steps = [
     { num: 1, text: "Sign in to Google Admin Console" },
-    { num: 2, text: "Navigate to: Apps > Web and mobile apps" },
-    { num: 3, text: "Click 'Add app' > 'Add custom SAML app'" },
-    { num: 4, text: "Enter any name (e.g., 'Azure AD Provisioning')" },
-    { num: 5, text: "Click 'Continue' through the SAML setup screens" },
-    { num: 6, text: "Find 'Automatic user provisioning' section" },
-    { num: 7, text: "Click 'SET UP AUTOMATIC USER PROVISIONING'" },
-    { num: 8, text: "Copy the 'Authorization token' value" },
+    { num: 2, text: "Navigate to: Security > Authentication > SSO with third party IdP" },
+    { num: 3, text: "Find your 'Azure AD SSO' profile" },
+    { num: 4, text: "Click on the profile to open it" },
+    { num: 5, text: "Look for 'Automatic user provisioning' section" },
+    { num: 6, text: "Click 'SET UP AUTOMATIC USER PROVISIONING'" },
+    { num: 7, text: "Copy the 'Authorization token' value" },
   ];
 
   return (
@@ -119,10 +119,17 @@ export function GoogleTokenModal({
                 variant="outline"
                 size="sm"
                 className="w-full justify-start"
-                onClick={() => window.open("https://admin.google.com/ac/apps/unified", "_blank")}
+                onClick={() => {
+                  const profileName = outputs?.[OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME] as string;
+                  const profileId = profileName?.split("/").pop();
+                  const url = profileId
+                    ? `https://admin.google.com/ac/security/sso/inboundsamlssoprofiles/${profileId}`
+                    : "https://admin.google.com/ac/security/sso";
+                  window.open(url, "_blank");
+                }}
               >
                 <ExternalLinkIcon className="mr-2 h-4 w-4" />
-                Open Google Admin Console - Apps
+                Open Your SAML Profile
               </Button>
               <div className="text-xs text-muted-foreground">
                 The token will look like: <code className="font-mono bg-white dark:bg-gray-800 px-1 py-0.5 rounded">2.MqPt7f3qkV0IFG...</code>

--- a/hooks/use-auto-check.ts
+++ b/hooks/use-auto-check.ts
@@ -69,7 +69,7 @@ export function useAutoCheck(executeCheck: (stepId: string) => Promise<void>) {
         // 1. Are automatable
         // 2. Have check functions
         // 3. Are not already completed (unless they failed with non-auth error)
-        const autoCheckSteps = ["G-1", "G-4", "G-5", "M-1", "M-6"];
+        const autoCheckSteps = ["G-4", "G-5", "M-1", "M-6"];
 
         for (const stepId of autoCheckSteps) {
           const status = stepsStatus[stepId];


### PR DESCRIPTION
## Summary
- implement IdpCredential typing and addIdpCredentials/listIdpCredentials
- drop obsolete Google automation steps
- add provisioning enablement step for existing SAML profile
- update registry, hooks and UI for simplified flow

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_683f8d08c0e88322b87a410b7f7b14d0