### PR TITLE
Fix ESLint warnings and improve hooks

### DIFF
--- a/app/actions/check-actions.ts
+++ b/app/actions/check-actions.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import { auth } from "@/app/(auth)/auth";
-import { isAPIEnablementError } from "@/lib/api/api-enablement-error";
 import {
   AuthenticationError,
   isAuthenticationError,

--- a/hooks/use-auto-check.ts
+++ b/hooks/use-auto-check.ts
@@ -1,4 +1,3 @@
-import { debounce } from "@/lib/utils";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAppSelector } from "./use-redux";
 import { useSessionSync } from "./use-session-sync";
@@ -23,8 +22,11 @@ export function useAutoCheck(executeCheck: (stepId: string) => Promise<void>) {
   }, [appConfig.domain]);
 
   // Debounced check function
-  const debouncedCheck = useCallback(
-    debounce(async () => {
+  const debouncedCheck = useCallback(() => {
+    if (checkTimeoutRef.current) {
+      clearTimeout(checkTimeoutRef.current);
+    }
+    checkTimeoutRef.current = setTimeout(async () => {
       // Skip if already checking
       if (hasChecked.current || isValidating) return;
 
@@ -98,9 +100,8 @@ export function useAutoCheck(executeCheck: (stepId: string) => Promise<void>) {
       } finally {
         setIsValidating(false);
       }
-    }, 2000),
-    [appConfig, stepsStatus, session, status, executeCheck, isValidating]
-  );
+    }, 2000);
+  }, [appConfig, stepsStatus, session, status, executeCheck, isValidating]);
 
   // Trigger debounced check when dependencies change
   useEffect(() => {

--- a/next-auth.d.ts
+++ b/next-auth.d.ts
@@ -1,7 +1,6 @@
 import type {
   DefaultSession,
   Profile as NextAuthProfile,
-  User,
 } from "next-auth";
 import type { JWT as NextAuthJWT } from "next-auth/jwt";
 


### PR DESCRIPTION
## Summary
- remove unused imports in `check-actions.ts` and `next-auth.d.ts`
- refactor `useAutoCheck` debounced handler to avoid ESLint warnings

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_683fb40461f0832282f6aed1c4ce4092