### PR TITLE
Centralize URL builder and update env types

### DIFF
--- a/app/(auth)/auth.ts
+++ b/app/(auth)/auth.ts
@@ -1,4 +1,5 @@
 import { withRetry } from "@/lib/api/utils";
+import { googleOAuthUrls, microsoftAuthUrls } from "@/lib/api/url-builder";
 import type { User } from "next-auth";
 import NextAuth from "next-auth";
 import type { JWT } from "next-auth/jwt";
@@ -25,7 +26,7 @@ function getUserKey(_userOrToken?: User | JWT): string {
  */
 async function refreshGoogleToken(token: JWT): Promise<JWT> {
   try {
-    const response = await fetch("https://oauth2.googleapis.com/token", {
+    const response = await fetch(googleOAuthUrls.token(), {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
       body: new URLSearchParams({
@@ -69,7 +70,7 @@ async function refreshMicrosoftToken(token: JWT): Promise<JWT> {
     const tenantForRefresh =
       token.microsoftTenantId || process.env.MICROSOFT_TENANT_ID || "common";
     const response = await fetch(
-      `https://login.microsoftonline.com/${tenantForRefresh}/oauth2/v2.0/token`,
+      microsoftAuthUrls.token(tenantForRefresh),
       {
         method: "POST",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },

--- a/components/google-token-modal.tsx
+++ b/components/google-token-modal.tsx
@@ -15,7 +15,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useAppSelector } from "@/hooks/use-redux";
 import { OUTPUT_KEYS } from "@/lib/types";
-import { getGoogleSamlProfileUrl } from "@/lib/utils";
+import { portalUrls } from "@/lib/api/url-builder";
 import {
   CheckCircle2Icon,
   CopyIcon,
@@ -123,8 +123,8 @@ export function GoogleTokenModal({
                     OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME
                   ] as string;
                   const url = profileName
-                    ? getGoogleSamlProfileUrl(profileName)
-                    : "https://admin.google.com/ac/security/sso";
+                    ? portalUrls.google.sso.samlProfile(profileName)
+                    : portalUrls.google.sso.main();
                   window.open(url, "_blank");
                 }}
               >

--- a/lib/api/env.d.ts
+++ b/lib/api/env.d.ts
@@ -1,0 +1,29 @@
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      // API URLs
+      GOOGLE_API_BASE: string;
+      GOOGLE_IDENTITY_BASE: string;
+      GRAPH_API_BASE: string;
+      GOOGLE_OAUTH_BASE?: string;
+      MICROSOFT_LOGIN_BASE?: string;
+
+      // Portal URLs
+      GOOGLE_ADMIN_CONSOLE_BASE?: string;
+      AZURE_PORTAL_BASE?: string;
+
+      // Auth configuration
+      AUTH_SECRET: string;
+      GOOGLE_CLIENT_ID: string;
+      GOOGLE_CLIENT_SECRET: string;
+      GOOGLE_ADMIN_SCOPES: string;
+      MICROSOFT_CLIENT_ID: string;
+      MICROSOFT_CLIENT_SECRET: string;
+      MICROSOFT_TENANT_ID?: string;
+      MICROSOFT_GRAPH_SCOPES: string;
+      NEXT_PUBLIC_MICROSOFT_TENANT_ID?: string;
+    }
+  }
+}
+
+export {};

--- a/lib/api/google.ts
+++ b/lib/api/google.ts
@@ -6,6 +6,7 @@ import {
 } from "./api-enablement-error";
 import { wrapAuthError } from "./auth-interceptor";
 import { APIError, fetchWithAuth, handleApiResponse } from "./utils";
+import { googleDirectoryUrls, googleIdentityUrls } from "./url-builder";
 
 export type DirectoryUser = admin_directory_v1.Schema$User;
 export type GoogleOrgUnit = admin_directory_v1.Schema$OrgUnit;
@@ -55,27 +56,6 @@ export interface IdpCredential {
 
 const GWS_CUSTOMER_ID = "my_customer";
 
-/** Build the base URL for Directory API calls. */
-function getDirectoryApiBaseUrl(): string {
-  const envBase = process.env.GOOGLE_API_BASE;
-  if (!envBase) {
-    console.error("CRITICAL: GOOGLE_API_BASE environment variable is not set!");
-    throw new Error("Google API base URL is not configured.");
-  }
-  return `${envBase}/admin/directory/v1`;
-}
-
-/** Build the base URL for Cloud Identity API calls. */
-function getCloudIdentityApiBaseUrl(): string {
-  const envBase = process.env.GOOGLE_IDENTITY_BASE;
-  if (!envBase) {
-    console.error(
-      "CRITICAL: GOOGLE_IDENTITY_BASE environment variable is not set!"
-    );
-    throw new Error("Google Cloud Identity API base URL is not configured.");
-  }
-  return `${envBase}/v1`;
-}
 
 function handleGoogleError(error: unknown): never {
   if (
@@ -101,12 +81,9 @@ export async function getDomainVerificationStatus(
   domainName: string
 ): Promise<boolean> {
   try {
-    const baseUrl = getDirectoryApiBaseUrl();
     const res = await fetchWithAuth(
-      `${baseUrl}/customer/${GWS_CUSTOMER_ID}/domains/${encodeURIComponent(
-        domainName
-      )}`,
-      token
+      googleDirectoryUrls.domains.get(GWS_CUSTOMER_ID, domainName),
+      token,
     );
     if (res.status === 404) return false;
     const data = await handleApiResponse<GoogleDomain>(res);
@@ -129,10 +106,9 @@ interface ListOrgUnitsResponse {
 /** List all organizational units. */
 export async function listOrgUnits(token: string): Promise<GoogleOrgUnit[]> {
   try {
-    const baseUrl = getDirectoryApiBaseUrl();
     const res = await fetchWithAuth(
-      `${baseUrl}/customer/${GWS_CUSTOMER_ID}/orgunits?type=all`,
-      token
+      googleDirectoryUrls.orgUnits.list(GWS_CUSTOMER_ID),
+      token,
     );
     const data = await handleApiResponse<ListOrgUnitsResponse>(res);
     if (typeof data === "object" && data !== null && "alreadyExists" in data)
@@ -152,19 +128,18 @@ export async function createOrgUnit(
   parentOrgUnitPath = "/"
 ): Promise<GoogleOrgUnit | { alreadyExists: true }> {
   try {
-    const baseUrl = getDirectoryApiBaseUrl();
     const res = await fetchWithAuth(
-      `${baseUrl}/customer/${GWS_CUSTOMER_ID}/orgunits`,
+      googleDirectoryUrls.orgUnits.create(GWS_CUSTOMER_ID),
       token,
       {
         method: "POST",
         body: JSON.stringify({ name, parentOrgUnitPath }),
-      }
+      },
     );
     console.log("Sending request to createOrgUnit:", {
       name,
       parentOrgUnitPath,
-      url: `${baseUrl}/customer/${GWS_CUSTOMER_ID}/orgunits`,
+      url: googleDirectoryUrls.orgUnits.create(GWS_CUSTOMER_ID),
     });
 
     return handleApiResponse<GoogleOrgUnit>(res);
@@ -179,7 +154,6 @@ export async function getOrgUnit(
   ouPath: string
 ): Promise<GoogleOrgUnit | null> {
   try {
-    const baseUrl = getDirectoryApiBaseUrl();
     console.log(
       `getOrgUnit: Fetching OU by path '${ouPath}' with token ${token}`
     );
@@ -193,9 +167,10 @@ export async function getOrgUnit(
     if (!relativePath) {
       return null;
     }
-    const fetchUrl = `${baseUrl}/customer/${GWS_CUSTOMER_ID}/orgunits/${encodeURIComponent(
-      relativePath
-    )}`;
+    const fetchUrl = googleDirectoryUrls.orgUnits.get(
+      GWS_CUSTOMER_ID,
+      relativePath,
+    );
     const res = await fetchWithAuth(fetchUrl, token);
 
     if (res.status === 404) {
@@ -218,8 +193,7 @@ export async function createUser(
   user: Partial<DirectoryUser>
 ): Promise<DirectoryUser | { alreadyExists: true }> {
   try {
-    const baseUrl = getDirectoryApiBaseUrl();
-    const res = await fetchWithAuth(`${baseUrl}/users`, token, {
+    const res = await fetchWithAuth(googleDirectoryUrls.users.create(), token, {
       method: "POST",
       body: JSON.stringify(user),
     });
@@ -235,12 +209,9 @@ export async function getUser(
   userKey: string
 ): Promise<DirectoryUser | null> {
   try {
-    const baseUrl = getDirectoryApiBaseUrl();
     const res = await fetchWithAuth(
-      `${baseUrl}/users/${encodeURIComponent(
-        userKey
-      )}?fields=isAdmin,suspended,primaryEmail,name,id,orgUnitPath`,
-      token
+      googleDirectoryUrls.users.get(userKey),
+      token,
     );
     if (res.status === 404) return null;
     const data = await handleApiResponse<DirectoryUser>(res);
@@ -264,14 +235,7 @@ export async function listUsers(
   }
 ): Promise<DirectoryUser[]> {
   try {
-    const baseUrl = getDirectoryApiBaseUrl();
-    const queryParams = new URLSearchParams();
-    if (params?.domain) queryParams.append("domain", params.domain);
-    if (params?.query) queryParams.append("query", params.query);
-    if (params?.orderBy) queryParams.append("orderBy", params.orderBy);
-    if (params?.maxResults)
-      queryParams.append("maxResults", params.maxResults.toString());
-    const url = `${baseUrl}/users${queryParams.toString() ? `?${queryParams}` : ""}`;
+    const url = googleDirectoryUrls.users.list(params);
     const res = await fetchWithAuth(url, token);
     const data = await handleApiResponse<{ users?: DirectoryUser[] }>(res);
     if (typeof data === "object" && data !== null && "alreadyExists" in data) {
@@ -289,14 +253,13 @@ export async function addDomain(
   domainName: string
 ): Promise<GoogleDomain | { alreadyExists: true }> {
   try {
-    const baseUrl = getDirectoryApiBaseUrl();
     const res = await fetchWithAuth(
-      `${baseUrl}/customer/${GWS_CUSTOMER_ID}/domains`,
+      googleDirectoryUrls.domains.create(GWS_CUSTOMER_ID),
       token,
       {
         method: "POST",
         body: JSON.stringify({ domainName }),
-      }
+      },
     );
     return handleApiResponse<GoogleDomain>(res);
   } catch (error) {
@@ -310,12 +273,9 @@ export async function getDomain(
   domainName: string
 ): Promise<GoogleDomain | null> {
   try {
-    const baseUrl = getDirectoryApiBaseUrl();
     const res = await fetchWithAuth(
-      `${baseUrl}/customer/${GWS_CUSTOMER_ID}/domains/${encodeURIComponent(
-        domainName
-      )}`,
-      token
+      googleDirectoryUrls.domains.get(GWS_CUSTOMER_ID, domainName),
+      token,
     );
     if (res.status === 404) return null;
     const data = await handleApiResponse<GoogleDomain>(res);
@@ -335,10 +295,9 @@ interface ListAdminRolesResponse {
 /** List available admin roles. */
 export async function listAdminRoles(token: string): Promise<GoogleRole[]> {
   try {
-    const baseUrl = getDirectoryApiBaseUrl();
     const res = await fetchWithAuth(
-      `${baseUrl}/customer/${GWS_CUSTOMER_ID}/roles`,
-      token
+      googleDirectoryUrls.roles.list(GWS_CUSTOMER_ID),
+      token,
     );
     const data = await handleApiResponse<ListAdminRolesResponse>(res);
     if (typeof data === "object" && data !== null && "alreadyExists" in data)
@@ -356,9 +315,8 @@ export async function assignAdminRole(
   roleId: string
 ): Promise<GoogleRoleAssignment | { alreadyExists: true }> {
   try {
-    const baseUrl = getDirectoryApiBaseUrl();
     const res = await fetchWithAuth(
-      `${baseUrl}/customer/${GWS_CUSTOMER_ID}/roleassignments`,
+      googleDirectoryUrls.roles.assignments.create(GWS_CUSTOMER_ID),
       token,
       {
         method: "POST",
@@ -367,7 +325,7 @@ export async function assignAdminRole(
           assignedTo: userEmail,
           scopeType: "CUSTOMER",
         }),
-      }
+      },
     );
     return handleApiResponse<GoogleRoleAssignment>(res);
   } catch (error) {
@@ -381,12 +339,9 @@ export async function listRoleAssignments(
   userKey: string
 ): Promise<GoogleRoleAssignment[]> {
   try {
-    const baseUrl = getDirectoryApiBaseUrl();
     const res = await fetchWithAuth(
-      `${baseUrl}/customer/${GWS_CUSTOMER_ID}/roleassignments?userKey=${encodeURIComponent(
-        userKey
-      )}`,
-      token
+      googleDirectoryUrls.roles.assignments.list(GWS_CUSTOMER_ID, userKey),
+      token,
     );
     const data = await handleApiResponse<{ items?: GoogleRoleAssignment[] }>(
       res
@@ -406,14 +361,13 @@ export async function createSamlProfile(
   displayName: string
 ): Promise<InboundSamlSsoProfile | { alreadyExists: true }> {
   try {
-    const cloudIdentityBaseUrl = getCloudIdentityApiBaseUrl();
     const res = await fetchWithAuth(
-      `${cloudIdentityBaseUrl}/inboundSamlSsoProfiles`,
+      googleIdentityUrls.samlProfiles.create(),
       token,
       {
         method: "POST",
         body: JSON.stringify({ displayName }),
-      }
+      },
     );
 
     const data = await handleApiResponse<{
@@ -447,10 +401,9 @@ export async function getSamlProfile(
   profileFullName: string
 ): Promise<InboundSamlSsoProfile | null> {
   try {
-    const cloudIdentityBaseUrl = getCloudIdentityApiBaseUrl();
     const res = await fetchWithAuth(
-      `${cloudIdentityBaseUrl}/${profileFullName}`,
-      token
+      googleIdentityUrls.samlProfiles.get(profileFullName),
+      token,
     );
     if (res.status === 404) return null;
     const data = await handleApiResponse<InboundSamlSsoProfile>(res);
@@ -469,10 +422,9 @@ export async function listSamlProfiles(
   token: string
 ): Promise<InboundSamlSsoProfile[]> {
   try {
-    const cloudIdentityBaseUrl = getCloudIdentityApiBaseUrl();
     const res = await fetchWithAuth(
-      `${cloudIdentityBaseUrl}/inboundSamlSsoProfiles`,
-      token
+      googleIdentityUrls.samlProfiles.list(),
+      token,
     );
     const data = await handleApiResponse<{
       inboundSamlSsoProfiles?: InboundSamlSsoProfile[];
@@ -492,20 +444,17 @@ export async function updateSamlProfile(
   config: Partial<Pick<InboundSamlSsoProfile, "idpConfig">>
 ): Promise<InboundSamlSsoProfile | { alreadyExists: true }> {
   try {
-    const cloudIdentityBaseUrl = getCloudIdentityApiBaseUrl();
     const updateMaskPaths: string[] = [];
     if (config.idpConfig) updateMaskPaths.push("idpConfig");
     const updateMask = updateMaskPaths.join(",");
 
     const res = await fetchWithAuth(
-      `${cloudIdentityBaseUrl}/${profileFullName}${
-        updateMask ? `?updateMask=${updateMask}` : ""
-      }`,
+      googleIdentityUrls.samlProfiles.update(profileFullName, updateMask),
       token,
       {
         method: "PATCH",
         body: JSON.stringify(config),
-      }
+      },
     );
     return handleApiResponse<InboundSamlSsoProfile>(res);
   } catch (error) {
@@ -523,14 +472,13 @@ export async function assignSamlToOrgUnits(
   assignments: AssignSamlSsoPayload["assignments"]
 ): Promise<object | { alreadyExists: true }> {
   try {
-    const cloudIdentityBaseUrl = getCloudIdentityApiBaseUrl();
     const res = await fetchWithAuth(
-      `${cloudIdentityBaseUrl}/${profileFullName}:assignToOrgUnits`,
+      googleIdentityUrls.samlProfiles.assignToOrgUnits(profileFullName),
       token,
       {
         method: "POST",
         body: JSON.stringify({ assignments } as AssignSamlSsoPayload),
-      }
+      },
     );
     return handleApiResponse<object>(res);
   } catch (error) {
@@ -549,15 +497,14 @@ export async function addIdpCredentials(
   pemData?: string
 ): Promise<{ success: boolean } | { alreadyExists: true }> {
   try {
-    const cloudIdentityBaseUrl = getCloudIdentityApiBaseUrl();
     const body = pemData ? { pemData } : {};
     const res = await fetchWithAuth(
-      `${cloudIdentityBaseUrl}/${profileFullName}/idpCredentials:add`,
+      googleIdentityUrls.samlProfiles.idpCredentials.add(profileFullName),
       token,
       {
         method: "POST",
         body: JSON.stringify(body),
-      }
+      },
     );
     return handleApiResponse(res);
   } catch (error) {
@@ -574,10 +521,9 @@ export async function listIdpCredentials(
   profileFullName: string
 ): Promise<IdpCredential[]> {
   try {
-    const cloudIdentityBaseUrl = getCloudIdentityApiBaseUrl();
     const res = await fetchWithAuth(
-      `${cloudIdentityBaseUrl}/${profileFullName}/idpCredentials`,
-      token
+      googleIdentityUrls.samlProfiles.idpCredentials.list(profileFullName),
+      token,
     );
     const data = await handleApiResponse<{ idpCredentials?: IdpCredential[] }>(
       res

--- a/lib/api/url-builder.ts
+++ b/lib/api/url-builder.ts
@@ -1,0 +1,220 @@
+/**
+ * Centralized URL builder for all external service URLs.
+ * Handles proper encoding and uses environment variables.
+ */
+
+// API Base URLs (from env)
+export const API_BASES = {
+  googleDirectory: process.env.GOOGLE_API_BASE || "https://admin.googleapis.com",
+  googleIdentity: process.env.GOOGLE_IDENTITY_BASE || "https://cloudidentity.googleapis.com",
+  microsoftGraph: process.env.GRAPH_API_BASE || "https://graph.microsoft.com/v1.0",
+  googleOAuth: process.env.GOOGLE_OAUTH_BASE || "https://oauth2.googleapis.com",
+  microsoftLogin: process.env.MICROSOFT_LOGIN_BASE || "https://login.microsoftonline.com",
+} as const;
+
+// UI/Portal Base URLs (from env)
+export const PORTAL_BASES = {
+  googleAdmin: process.env.GOOGLE_ADMIN_CONSOLE_BASE || "https://admin.google.com",
+  azurePortal: process.env.AZURE_PORTAL_BASE || "https://portal.azure.com",
+} as const;
+
+// Google Directory API URLs
+export const googleDirectoryUrls = {
+  base: () => `${API_BASES.googleDirectory}/admin/directory/v1`,
+  
+  orgUnits: {
+    list: (customerId: string) => 
+      `${googleDirectoryUrls.base()}/customer/${encodeURIComponent(customerId)}/orgunits?type=all`,
+    create: (customerId: string) => 
+      `${googleDirectoryUrls.base()}/customer/${encodeURIComponent(customerId)}/orgunits`,
+    get: (customerId: string, ouPath: string) => {
+      const relativePath = ouPath.startsWith("/") ? ouPath.substring(1) : ouPath;
+      return `${googleDirectoryUrls.base()}/customer/${encodeURIComponent(customerId)}/orgunits/${encodeURIComponent(relativePath)}`;
+    },
+  },
+  
+  users: {
+    list: (params?: { domain?: string; query?: string; orderBy?: string; maxResults?: number }) => {
+      const url = new URL(`${googleDirectoryUrls.base()}/users`);
+      if (params?.domain) url.searchParams.append("domain", params.domain);
+      if (params?.query) url.searchParams.append("query", params.query);
+      if (params?.orderBy) url.searchParams.append("orderBy", params.orderBy);
+      if (params?.maxResults) url.searchParams.append("maxResults", params.maxResults.toString());
+      return url.toString();
+    },
+    get: (userKey: string) => 
+      `${googleDirectoryUrls.base()}/users/${encodeURIComponent(userKey)}?fields=isAdmin,suspended,primaryEmail,name,id,orgUnitPath`,
+    create: () => `${googleDirectoryUrls.base()}/users`,
+  },
+  
+  domains: {
+    list: (customerId: string) => 
+      `${googleDirectoryUrls.base()}/customer/${encodeURIComponent(customerId)}/domains`,
+    get: (customerId: string, domainName: string) => 
+      `${googleDirectoryUrls.base()}/customer/${encodeURIComponent(customerId)}/domains/${encodeURIComponent(domainName)}`,
+    create: (customerId: string) => 
+      `${googleDirectoryUrls.base()}/customer/${encodeURIComponent(customerId)}/domains`,
+  },
+  
+  roles: {
+    list: (customerId: string) => 
+      `${googleDirectoryUrls.base()}/customer/${encodeURIComponent(customerId)}/roles`,
+    assignments: {
+      list: (customerId: string, userKey: string) => 
+        `${googleDirectoryUrls.base()}/customer/${encodeURIComponent(customerId)}/roleassignments?userKey=${encodeURIComponent(userKey)}`,
+      create: (customerId: string) => 
+        `${googleDirectoryUrls.base()}/customer/${encodeURIComponent(customerId)}/roleassignments`,
+    },
+  },
+};
+
+// Google Cloud Identity API URLs
+export const googleIdentityUrls = {
+  base: () => `${API_BASES.googleIdentity}/v1`,
+  
+  samlProfiles: {
+    list: () => `${googleIdentityUrls.base()}/inboundSamlSsoProfiles`,
+    get: (profileFullName: string) => `${googleIdentityUrls.base()}/${profileFullName}`,
+    create: () => `${googleIdentityUrls.base()}/inboundSamlSsoProfiles`,
+    update: (profileFullName: string, updateMask?: string) => {
+      const url = new URL(`${googleIdentityUrls.base()}/${profileFullName}`);
+      if (updateMask) url.searchParams.append("updateMask", updateMask);
+      return url.toString();
+    },
+    assignToOrgUnits: (profileFullName: string) => 
+      `${googleIdentityUrls.base()}/${profileFullName}:assignToOrgUnits`,
+    idpCredentials: {
+      list: (profileFullName: string) => 
+        `${googleIdentityUrls.base()}/${profileFullName}/idpCredentials`,
+      add: (profileFullName: string) => 
+        `${googleIdentityUrls.base()}/${profileFullName}/idpCredentials:add`,
+    },
+  },
+};
+
+// Microsoft Graph API URLs
+export const microsoftGraphUrls = {
+  base: () => API_BASES.microsoftGraph,
+  
+  applications: {
+    list: (filter?: string) => {
+      const url = new URL(`${microsoftGraphUrls.base()}/applications`);
+      if (filter) url.searchParams.append("$filter", filter);
+      return url.toString();
+    },
+    get: (appObjectId: string) => 
+      `${microsoftGraphUrls.base()}/applications/${appObjectId}?$select=id,appId,displayName,identifierUris,web`,
+    update: (appObjectId: string) => 
+      `${microsoftGraphUrls.base()}/applications/${appObjectId}`,
+  },
+  
+  servicePrincipals: {
+    list: (filter?: string) => {
+      const url = new URL(`${microsoftGraphUrls.base()}/servicePrincipals`);
+      if (filter) url.searchParams.append("$filter", filter);
+      url.searchParams.append("$select", "id,appId,displayName,accountEnabled,appOwnerOrganizationId");
+      return url.toString();
+    },
+    get: (spObjectId: string) => 
+      `${microsoftGraphUrls.base()}/servicePrincipals/${spObjectId}?$select=id,appId,displayName,accountEnabled`,
+    update: (spObjectId: string) => 
+      `${microsoftGraphUrls.base()}/servicePrincipals/${spObjectId}`,
+    appRoleAssignments: {
+      list: (spObjectId: string) => 
+        `${microsoftGraphUrls.base()}/servicePrincipals/${spObjectId}/appRoleAssignedTo`,
+      create: (spObjectId: string) => 
+        `${microsoftGraphUrls.base()}/servicePrincipals/${spObjectId}/appRoleAssignedTo`,
+    },
+    synchronization: {
+      jobs: {
+        list: (spObjectId: string) => 
+          `${microsoftGraphUrls.base()}/servicePrincipals/${spObjectId}/synchronization/jobs`,
+        get: (spObjectId: string, jobId: string) => 
+          `${microsoftGraphUrls.base()}/servicePrincipals/${spObjectId}/synchronization/jobs/${jobId}`,
+        create: (spObjectId: string) => 
+          `${microsoftGraphUrls.base()}/servicePrincipals/${spObjectId}/synchronization/jobs`,
+        start: (spObjectId: string, jobId: string) => 
+          `${microsoftGraphUrls.base()}/servicePrincipals/${spObjectId}/synchronization/jobs/${jobId}/start`,
+        schema: (spObjectId: string, jobId: string) => 
+          `${microsoftGraphUrls.base()}/servicePrincipals/${spObjectId}/synchronization/jobs/${jobId}/schema`,
+      },
+      secrets: (spObjectId: string) => 
+        `${microsoftGraphUrls.base()}/servicePrincipals/${spObjectId}/synchronization/secrets`,
+    },
+  },
+  
+  applicationTemplates: {
+    instantiate: (templateId: string) => 
+      `${microsoftGraphUrls.base()}/applicationTemplates/${templateId}/instantiate`,
+  },
+  
+  me: {
+    memberOf: () => 
+      `${microsoftGraphUrls.base()}/me/memberOf/microsoft.graph.directoryRole?$select=displayName,roleTemplateId`,
+  },
+};
+
+// Microsoft Auth URLs
+export const microsoftAuthUrls = {
+  token: (tenantId: string) => 
+    `${API_BASES.microsoftLogin}/${tenantId}/oauth2/v2.0/token`,
+  openIdConfig: (domain: string) => 
+    `${API_BASES.microsoftLogin}/${domain}/.well-known/openid-configuration`,
+  samlMetadata: (tenantId: string, appId: string) => 
+    `${API_BASES.microsoftLogin}/${tenantId}/federationmetadata/2007-06/federationmetadata.xml?appid=${appId}`,
+};
+
+// Google OAuth URLs
+export const googleOAuthUrls = {
+  token: () => `${API_BASES.googleOAuth}/token`,
+};
+
+// Portal/Console URLs for UI navigation
+export const portalUrls = {
+  google: {
+    orgUnits: {
+      list: () => `${PORTAL_BASES.googleAdmin}/ac/orgunits`,
+      details: (ouPath: string) => 
+        `${PORTAL_BASES.googleAdmin}/ac/orgunits/details?ouPath=${encodeURIComponent(ouPath)}`,
+    },
+    users: {
+      list: () => `${PORTAL_BASES.googleAdmin}/ac/users`,
+      details: (userEmail: string) => 
+        `${PORTAL_BASES.googleAdmin}/ac/users/${encodeURIComponent(userEmail)}`,
+    },
+    domains: {
+      manage: (domain?: string) => {
+        const url = new URL(`${PORTAL_BASES.googleAdmin}/ac/domains/manage`);
+        if (domain) url.searchParams.append("domain", domain);
+        return url.toString();
+      },
+    },
+    sso: {
+      main: () => `${PORTAL_BASES.googleAdmin}/ac/sso`,
+      samlProfile: (profileFullName: string) => {
+        // Extract profile ID and properly encode for the Admin Console URL
+        const profileId = profileFullName.split("/").pop();
+        if (!profileId) return portalUrls.google.sso.main();
+        
+        // The Admin Console expects the profile reference in a specific format
+        // with forward slashes encoded as %2F
+        const encodedProfileRef = `inboundSamlSsoProfiles${encodeURIComponent("/" + profileId)}`;
+        return `${PORTAL_BASES.googleAdmin}/ac/security/sso/sso-profiles/${encodedProfileRef}`;
+      },
+    },
+  },
+  
+  azure: {
+    enterpriseApp: {
+      overview: (spId: string, appId: string) => 
+        `${PORTAL_BASES.azurePortal}/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Overview/servicePrincipalId/${spId}/appId/${appId}`,
+      provisioning: (spId: string, appId: string) => 
+        `${PORTAL_BASES.azurePortal}/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/ProvisioningManagement/appId/${appId}/objectId/${spId}`,
+      singleSignOn: (spId: string, appId: string) => 
+        `${PORTAL_BASES.azurePortal}/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/SingleSignOn/appId/${appId}/objectId/${spId}`,
+      usersAndGroups: (spId: string, appId: string) => 
+        `${PORTAL_BASES.azurePortal}/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/UsersAndGroups/servicePrincipalId/${spId}/appId/${appId}`,
+    },
+    myApps: () => "https://myapps.microsoft.com",
+  },
+};

--- a/lib/steps/google/assign-saml-profile.ts
+++ b/lib/steps/google/assign-saml-profile.ts
@@ -1,4 +1,5 @@
 import type { StepDefinition } from "../../types";
+import { portalUrls } from "@/lib/api/url-builder";
 
 /**
  * Step definition for assigning the Google SAML profile to users or organizational units.
@@ -12,7 +13,7 @@ export const g7AssignSamlProfile: StepDefinition = {
   automatable: true,
   requires: ["G-6"],
   adminUrls: {
-    configure: "https://admin.google.com/ac/sso",
-    verify: "https://admin.google.com/ac/sso",
+    configure: portalUrls.google.sso.main(),
+    verify: portalUrls.google.sso.main(),
   },
 };

--- a/lib/steps/google/create-automation-ou.ts
+++ b/lib/steps/google/create-automation-ou.ts
@@ -1,5 +1,6 @@
 import type { StepDefinition } from "../../types";
 import { OUTPUT_KEYS } from "../../types";
+import { portalUrls } from "@/lib/api/url-builder";
 /**
  * Step definition for creating the dedicated `Automation` organizational unit.
  */
@@ -13,10 +14,10 @@ export const g1CreateAutomationOu: StepDefinition = {
   automatable: true,
   requires: [],
   adminUrls: {
-    configure: "https://admin.google.com/ac/orgunits",
+    configure: portalUrls.google.orgUnits.list(),
     verify: (outputs) =>
       outputs[OUTPUT_KEYS.AUTOMATION_OU_PATH]
-        ? `https://admin.google.com/ac/orgunits/details?ouPath=${outputs[OUTPUT_KEYS.AUTOMATION_OU_PATH] as string}`
-        : "https://admin.google.com/ac/orgunits",
+        ? portalUrls.google.orgUnits.details(outputs[OUTPUT_KEYS.AUTOMATION_OU_PATH] as string)
+        : portalUrls.google.orgUnits.list(),
   },
 };

--- a/lib/steps/google/create-provisioning-user.ts
+++ b/lib/steps/google/create-provisioning-user.ts
@@ -1,5 +1,6 @@
 import type { StepDefinition } from "../../types";
 import { OUTPUT_KEYS } from "../../types";
+import { portalUrls } from "@/lib/api/url-builder";
 /**
  * Step definition for creating the Azure AD provisioning user in Google Workspace.
  */
@@ -15,11 +16,11 @@ export const g2CreateProvisioningUser: StepDefinition = {
   adminUrls: {
     configure: (outputs) =>
       outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL]
-        ? `https://admin.google.com/ac/users/${outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL] as string}`
-        : "https://admin.google.com/ac/users",
+        ? portalUrls.google.users.details(outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL] as string)
+        : portalUrls.google.users.list(),
     verify: (outputs) =>
       outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL]
-        ? `https://admin.google.com/ac/users/${outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL] as string}`
-        : "https://admin.google.com/ac/users",
+        ? portalUrls.google.users.details(outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL] as string)
+        : portalUrls.google.users.list(),
   },
 };

--- a/lib/steps/google/exclude-automation-ou.ts
+++ b/lib/steps/google/exclude-automation-ou.ts
@@ -1,4 +1,5 @@
 import type { StepDefinition } from "../../types";
+import { portalUrls } from "@/lib/api/url-builder";
 
 /**
  * Step definition for optionally excluding the Automation OU from SSO.
@@ -12,7 +13,7 @@ export const g8ExcludeAutomationOu: StepDefinition = {
   automatable: true,
   requires: ["G-7"],
   adminUrls: {
-    configure: "https://admin.google.com/ac/sso",
-    verify: "https://admin.google.com/ac/sso",
+    configure: portalUrls.google.sso.main(),
+    verify: portalUrls.google.sso.main(),
   },
 };

--- a/lib/steps/google/grant-super-admin.ts
+++ b/lib/steps/google/grant-super-admin.ts
@@ -1,5 +1,6 @@
 import type { StepDefinition } from "../../types";
 import { OUTPUT_KEYS } from "../../types";
+import { portalUrls } from "@/lib/api/url-builder";
 /**
  * Step definition for granting super admin privileges to the provisioning user.
  */
@@ -15,11 +16,11 @@ export const g3GrantSuperAdmin: StepDefinition = {
   adminUrls: {
     configure: (outputs) =>
       outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL]
-        ? `https://admin.google.com/ac/users/${outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL] as string}`
-        : "https://admin.google.com/ac/users",
+        ? portalUrls.google.users.details(outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL] as string)
+        : portalUrls.google.users.list(),
     verify: (outputs) =>
       outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL]
-        ? `https://admin.google.com/ac/users/${outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL] as string}`
-        : "https://admin.google.com/ac/users",
+        ? portalUrls.google.users.details(outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL] as string)
+        : portalUrls.google.users.list(),
   },
 };

--- a/lib/steps/google/initiate-saml-profile.ts
+++ b/lib/steps/google/initiate-saml-profile.ts
@@ -1,4 +1,5 @@
 import type { StepDefinition } from "../../types";
+import { portalUrls } from "@/lib/api/url-builder";
 
 /**
  * Step definition for initiating the Google SAML profile and retrieving SP details.
@@ -12,7 +13,7 @@ export const g5InitiateSamlProfile: StepDefinition = {
   automatable: true,
   requires: ["G-4"],
   adminUrls: {
-    configure: "https://admin.google.com/ac/sso",
-    verify: "https://admin.google.com/ac/sso",
+    configure: portalUrls.google.sso.main(),
+    verify: portalUrls.google.sso.main(),
   },
 };

--- a/lib/steps/google/update-saml-profile.ts
+++ b/lib/steps/google/update-saml-profile.ts
@@ -1,4 +1,5 @@
 import type { StepDefinition } from "../../types";
+import { portalUrls } from "@/lib/api/url-builder";
 
 /**
  * Step definition for updating the Google SAML profile with Azure AD metadata.
@@ -12,7 +13,7 @@ export const g6UpdateSamlProfile: StepDefinition = {
   automatable: true,
   requires: ["G-5", "M-8"],
   adminUrls: {
-    configure: "https://admin.google.com/ac/sso",
-    verify: "https://admin.google.com/ac/sso",
+    configure: portalUrls.google.sso.main(),
+    verify: portalUrls.google.sso.main(),
   },
 };

--- a/lib/steps/google/verify-domain.ts
+++ b/lib/steps/google/verify-domain.ts
@@ -1,4 +1,5 @@
 import type { StepDefinition } from "../../types";
+import { portalUrls } from "@/lib/api/url-builder";
 
 /**
  * Step definition for verifying the primary domain used for federation.
@@ -12,7 +13,7 @@ export const g4VerifyDomain: StepDefinition = {
   automatable: true,
   requires: [],
   adminUrls: {
-    configure: "https://admin.google.com/ac/domains/manage",
-    verify: "https://admin.google.com/ac/domains/manage",
+    configure: portalUrls.google.domains.manage(),
+    verify: portalUrls.google.domains.manage(),
   },
 };

--- a/lib/steps/microsoft/assign-users-sso.ts
+++ b/lib/steps/microsoft/assign-users-sso.ts
@@ -1,6 +1,6 @@
 import type { StepDefinition } from "../../types";
 import { OUTPUT_KEYS } from "../../types";
-import { getAzurePortalUrl } from "../../utils";
+import { portalUrls } from "@/lib/api/url-builder";
 /**
  * Step definition for assigning users or groups to the Azure SSO application.
  */
@@ -18,13 +18,19 @@ export const m9AssignUsersSso: StepDefinition = {
       const spId = outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.SAML_SSO_APP_ID];
       if (!spId || !appId) return null;
-      return getAzurePortalUrl("UsersAndGroups", spId as string, appId as string);
+      return portalUrls.azure.enterpriseApp.usersAndGroups(
+        spId as string,
+        appId as string,
+      );
     },
     verify: (outputs) => {
       const spId = outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.SAML_SSO_APP_ID];
       if (!spId || !appId) return null;
-      return getAzurePortalUrl("UsersAndGroups", spId as string, appId as string);
+      return portalUrls.azure.enterpriseApp.usersAndGroups(
+        spId as string,
+        appId as string,
+      );
     },
   },
 };

--- a/lib/steps/microsoft/authorize-provisioning.ts
+++ b/lib/steps/microsoft/authorize-provisioning.ts
@@ -1,6 +1,6 @@
 import type { StepDefinition } from "../../types";
 import { OUTPUT_KEYS } from "../../types";
-import { getAzurePortalUrl } from "../../utils";
+import { portalUrls } from "@/lib/api/url-builder";
 /**
  * Step definition guiding the admin to authorize the Azure provisioning connection.
  */
@@ -18,13 +18,19 @@ export const m3AuthorizeProvisioning: StepDefinition = {
       const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
       if (!spId || !appId) return null;
-      return getAzurePortalUrl("ProvisioningManagement", spId as string, appId as string);
+      return portalUrls.azure.enterpriseApp.provisioning(
+        spId as string,
+        appId as string,
+      );
     },
     verify: (outputs) => {
       const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
       if (!spId || !appId) return null;
-      return getAzurePortalUrl("ProvisioningManagement", spId as string, appId as string);
+      return portalUrls.azure.enterpriseApp.provisioning(
+        spId as string,
+        appId as string,
+      );
     },
   },
 };

--- a/lib/steps/microsoft/configure-attribute-mappings.ts
+++ b/lib/steps/microsoft/configure-attribute-mappings.ts
@@ -1,6 +1,6 @@
 import type { StepDefinition } from "../../types";
 import { OUTPUT_KEYS } from "../../types";
-import { getAzurePortalUrl } from "../../utils";
+import { portalUrls } from "@/lib/api/url-builder";
 /**
  * Step definition for configuring attribute mappings in the provisioning app.
  */
@@ -18,13 +18,19 @@ export const m4ConfigureAttributeMappings: StepDefinition = {
       const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
       if (!spId || !appId) return null;
-      return getAzurePortalUrl("ProvisioningManagement", spId as string, appId as string);
+      return portalUrls.azure.enterpriseApp.provisioning(
+        spId as string,
+        appId as string,
+      );
     },
     verify: (outputs) => {
       const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
       if (!spId || !appId) return null;
-      return getAzurePortalUrl("ProvisioningManagement", spId as string, appId as string);
+      return portalUrls.azure.enterpriseApp.provisioning(
+        spId as string,
+        appId as string,
+      );
     },
   },
 };

--- a/lib/steps/microsoft/configure-saml-app.ts
+++ b/lib/steps/microsoft/configure-saml-app.ts
@@ -1,6 +1,6 @@
 import type { StepDefinition } from "../../types";
 import { OUTPUT_KEYS } from "../../types";
-import { getAzurePortalUrl } from "../../utils";
+import { portalUrls } from "@/lib/api/url-builder";
 /**
  * Step definition for configuring the Azure AD SAML application with Google details.
  */
@@ -18,13 +18,19 @@ export const m7ConfigureSamlApp: StepDefinition = {
       const spId = outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.SAML_SSO_APP_ID];
       if (!spId || !appId) return null;
-      return getAzurePortalUrl("SingleSignOn", spId as string, appId as string);
+      return portalUrls.azure.enterpriseApp.singleSignOn(
+        spId as string,
+        appId as string,
+      );
     },
     verify: (outputs) => {
       const spId = outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.SAML_SSO_APP_ID];
       if (!spId || !appId) return null;
-      return getAzurePortalUrl("SingleSignOn", spId as string, appId as string);
+      return portalUrls.azure.enterpriseApp.singleSignOn(
+        spId as string,
+        appId as string,
+      );
     },
   },
 };

--- a/lib/steps/microsoft/create-provisioning-app.ts
+++ b/lib/steps/microsoft/create-provisioning-app.ts
@@ -1,6 +1,6 @@
 import type { StepDefinition } from "../../types";
 import { OUTPUT_KEYS } from "../../types";
-import { getAzurePortalUrl } from "../../utils";
+import { portalUrls } from "@/lib/api/url-builder";
 /**
  * Step definition for creating the enterprise application used for provisioning.
  */
@@ -18,13 +18,13 @@ export const m1CreateProvisioningApp: StepDefinition = {
       const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
       if (!spId || !appId) return null;
-      return getAzurePortalUrl("Overview", spId as string, appId as string);
+      return portalUrls.azure.enterpriseApp.overview(spId as string, appId as string);
     },
     verify: (outputs) => {
       const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
       if (!spId || !appId) return null;
-      return getAzurePortalUrl("Overview", spId as string, appId as string);
+      return portalUrls.azure.enterpriseApp.overview(spId as string, appId as string);
     },
   },
 };

--- a/lib/steps/microsoft/create-saml-app.ts
+++ b/lib/steps/microsoft/create-saml-app.ts
@@ -1,6 +1,6 @@
 import type { StepDefinition } from "../../types";
 import { OUTPUT_KEYS } from "../../types";
-import { getAzurePortalUrl } from "../../utils";
+import { portalUrls } from "@/lib/api/url-builder";
 /**
  * Step definition for creating the Azure AD enterprise app used for SAML SSO.
  */
@@ -18,13 +18,13 @@ export const m6CreateSamlApp: StepDefinition = {
       const spId = outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.SAML_SSO_APP_ID];
       if (!spId || !appId) return null;
-      return getAzurePortalUrl("Overview", spId as string, appId as string);
+      return portalUrls.azure.enterpriseApp.overview(spId as string, appId as string);
     },
     verify: (outputs) => {
       const spId = outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.SAML_SSO_APP_ID];
       if (!spId || !appId) return null;
-      return getAzurePortalUrl("Overview", spId as string, appId as string);
+      return portalUrls.azure.enterpriseApp.overview(spId as string, appId as string);
     },
   },
 };

--- a/lib/steps/microsoft/enable-provisioning-sp.ts
+++ b/lib/steps/microsoft/enable-provisioning-sp.ts
@@ -1,6 +1,6 @@
 import type { StepDefinition } from "../../types";
 import { OUTPUT_KEYS } from "../../types";
-import { getAzurePortalUrl } from "../../utils";
+import { portalUrls } from "@/lib/api/url-builder";
 /**
  * Step definition for enabling the Azure AD provisioning service principal.
  */
@@ -18,13 +18,13 @@ export const m2EnableProvisioningSp: StepDefinition = {
       const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
       if (!spId || !appId) return null;
-      return getAzurePortalUrl("Overview", spId as string, appId as string);
+      return portalUrls.azure.enterpriseApp.overview(spId as string, appId as string);
     },
     verify: (outputs) => {
       const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
       if (!spId || !appId) return null;
-      return getAzurePortalUrl("Overview", spId as string, appId as string);
+      return portalUrls.azure.enterpriseApp.overview(spId as string, appId as string);
     },
   },
 };

--- a/lib/steps/microsoft/retrieve-idp-metadata.ts
+++ b/lib/steps/microsoft/retrieve-idp-metadata.ts
@@ -1,6 +1,6 @@
 import type { StepDefinition } from "../../types";
 import { OUTPUT_KEYS } from "../../types";
-import { getAzurePortalUrl } from "../../utils";
+import { portalUrls } from "@/lib/api/url-builder";
 /**
  * Step definition for retrieving Azure AD IdP metadata for Google Workspace.
  */
@@ -18,13 +18,19 @@ export const m8RetrieveIdpMetadata: StepDefinition = {
       const spId = outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.SAML_SSO_APP_ID];
       if (!spId || !appId) return null;
-      return getAzurePortalUrl("SingleSignOn", spId as string, appId as string);
+      return portalUrls.azure.enterpriseApp.singleSignOn(
+        spId as string,
+        appId as string,
+      );
     },
     verify: (outputs) => {
       const spId = outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.SAML_SSO_APP_ID];
       if (!spId || !appId) return null;
-      return getAzurePortalUrl("SingleSignOn", spId as string, appId as string);
+      return portalUrls.azure.enterpriseApp.singleSignOn(
+        spId as string,
+        appId as string,
+      );
     },
   },
 };

--- a/lib/steps/microsoft/start-provisioning.ts
+++ b/lib/steps/microsoft/start-provisioning.ts
@@ -1,6 +1,6 @@
 import type { StepDefinition } from "../../types";
 import { OUTPUT_KEYS } from "../../types";
-import { getAzurePortalUrl } from "../../utils";
+import { portalUrls } from "@/lib/api/url-builder";
 /**
  * Step definition for starting the Azure AD provisioning job.
  */
@@ -18,13 +18,19 @@ export const m5StartProvisioning: StepDefinition = {
       const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
       if (!spId || !appId) return null;
-      return getAzurePortalUrl("ProvisioningManagement", spId as string, appId as string);
+      return portalUrls.azure.enterpriseApp.provisioning(
+        spId as string,
+        appId as string,
+      );
     },
     verify: (outputs) => {
       const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
       if (!spId || !appId) return null;
-      return getAzurePortalUrl("ProvisioningManagement", spId as string, appId as string);
+      return portalUrls.azure.enterpriseApp.provisioning(
+        spId as string,
+        appId as string,
+      );
     },
   },
 };

--- a/lib/steps/microsoft/test-sso.ts
+++ b/lib/steps/microsoft/test-sso.ts
@@ -1,4 +1,5 @@
 import type { StepDefinition } from "../../types";
+import { portalUrls } from "@/lib/api/url-builder";
 
 /**
  * Step definition for manual testing of the complete SSO flow.
@@ -12,7 +13,7 @@ export const m10TestSso: StepDefinition = {
   automatable: false,
   requires: ["G-7", "M-9"],
   adminUrls: {
-    configure: "https://myapps.microsoft.com",
-    verify: "https://myapps.microsoft.com",
+    configure: portalUrls.azure.myApps(),
+    verify: portalUrls.azure.myApps(),
   },
 };


### PR DESCRIPTION
## Summary
- add environment variables for portal URLs
- centralize URL building in `lib/api/url-builder.ts`
- wire API clients and auth flow to use the new URL helpers
- replace hardcoded URLs in steps, actions and components
- add type definitions for URL-related environment vars

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_683fc4cdeb488322b33115c09097d9db