### PR TITLE
Centralized error dialog integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ that workflow.
 
 - Use `APIError` class for consistent API error representation
 - Server actions return standardized `ActionResult<T>` or `StepExecutionResult`
-- Client-side errors displayed via toast notifications (sonner)
+- Client-side errors displayed via a Redux-driven error dialog
 - Graceful degradation for missing authentication or configuration
 
 ### Data Flow Pattern

--- a/README.md
+++ b/README.md
@@ -173,11 +173,12 @@ The dashboard now features enhanced step cards that display:
 
 ### Authentication Error Handling
 
-The application includes robust authentication error handling:
+Errors are displayed through a centralized error dialog managed by Redux:
 
 - Automatic detection of expired tokens
-- Clear user notifications with action buttons
-- Graceful fallback for API errors
+- Modal dialog with a sign-in action when authentication expires
+- API enablement errors show an "Enable API" button
+- Other errors include diagnostic details and can be dismissed
 - Session persistence across token refreshes
 
 ## Testing

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -3,10 +3,12 @@
 import { useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { AlertTriangleIcon, LogInIcon } from "lucide-react";
+import { AlertTriangleIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { isAuthenticationError } from "@/lib/api/auth-interceptor";
 import { APIError } from "@/lib/api/utils";
+import { useAppDispatch } from "@/hooks/use-redux";
+import { showError } from "@/lib/redux/slices/errors";
 
 export default function Error({
   error,
@@ -16,72 +18,74 @@ export default function Error({
   reset: () => void;
 }) {
   const router = useRouter();
+  const dispatch = useAppDispatch();
 
   useEffect(() => {
     console.error("Route error:", error);
-  }, [error]);
 
-  if (
-    error instanceof APIError &&
-    error.message?.includes("has not been used in project")
-  ) {
-    const apiMatch = error.message.match(
-      /https:\/\/console\.developers\.google\.com[^\s]+/,
-    );
-    const enableUrl = apiMatch ? apiMatch[0] : null;
+    if (isAuthenticationError(error)) {
+      dispatch(showError({
+        error: {
+          title: "Authentication Required",
+          message: error.message,
+          code: "AUTH_EXPIRED",
+          provider: error.provider,
+          actions: [{
+            label: "Sign In",
+            onClick: () => router.push("/login"),
+            variant: "default",
+          }]
+        },
+        dismissible: false // Can't dismiss, must sign in
+      }));
+    } else if (error instanceof APIError && error.message?.includes("has not been used in project")) {
+      const apiMatch = error.message.match(
+        /https:\/\/console\.developers\.google\.com[^\s]+/,
+      );
+      const enableUrl = apiMatch ? apiMatch[0] : null;
 
-    return (
-      <div className="min-h-screen flex items-center justify-center p-4">
-        <Card className="max-w-md">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-orange-600">
-              <AlertTriangleIcon className="h-5 w-5" />
-              API Not Enabled
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <p className="text-sm">
-              A required Google Cloud API is not enabled for your project.
-            </p>
-            {enableUrl && (
-              <div className="space-y-2">
-                <Button
-                  onClick={() => window.open(enableUrl, "_blank")}
-                  className="w-full"
-                >
-                  Enable API
-                </Button>
-                <p className="text-xs text-muted-foreground text-center">
-                  After enabling, wait 2-3 minutes before retrying
-                </p>
-              </div>
-            )}
-            <Button onClick={reset} variant="outline" className="w-full">
-              Retry
-            </Button>
-          </CardContent>
-        </Card>
-      </div>
-    );
-  }
+      dispatch(showError({
+        error: {
+          title: "API Not Enabled",
+          message: "A required Google Cloud API is not enabled for your project.",
+          code: "API_NOT_ENABLED",
+          details: { enableUrl },
+          actions: enableUrl ? [{
+            label: "Enable API",
+            onClick: () => window.open(enableUrl, "_blank"),
+            variant: "default",
+          }, {
+            label: "Retry",
+            onClick: reset,
+            variant: "outline",
+          }] : [{
+            label: "Retry",
+            onClick: reset,
+            variant: "default",
+          }]
+        },
+        dismissible: true
+      }));
+    }
+  }, [error, router, dispatch, reset]);
 
-  if (isAuthenticationError(error)) {
+  // Show a fallback UI for non-handled errors
+  if (!isAuthenticationError(error) && !(error instanceof APIError)) {
     return (
       <div className="min-h-screen flex items-center justify-center p-4">
         <Card className="max-w-md">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
-              <AlertTriangleIcon className="h-5 w-5 text-orange-500" />
-              Authentication Required
+              <AlertTriangleIcon className="h-5 w-5 text-red-500" />
+              Something went wrong
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
-            <p className="text-sm text-muted-foreground">
-              Your session has expired. Please sign in again to continue.
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              {error.message || "An unexpected error occurred"}
             </p>
-            <Button onClick={() => router.push("/login")} className="w-full">
-              <LogInIcon className="mr-2 h-4 w-4" />
-              Go to Login
+            <Button onClick={reset} className="w-full">
+              Try again
             </Button>
           </CardContent>
         </Card>
@@ -89,24 +93,6 @@ export default function Error({
     );
   }
 
-  return (
-    <div className="min-h-screen flex items-center justify-center p-4">
-      <Card className="max-w-md">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <AlertTriangleIcon className="h-5 w-5 text-red-500" />
-            Something went wrong
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <p className="text-sm text-gray-600 dark:text-gray-400">
-            {error.message || "An unexpected error occurred"}
-          </p>
-          <Button onClick={reset} className="w-full">
-            Try again
-          </Button>
-        </CardContent>
-      </Card>
-    </div>
-  );
+  // For handled errors, return null as the error dialog will show
+  return null;
 }

--- a/components/AGENTS.md
+++ b/components/AGENTS.md
@@ -12,7 +12,7 @@ Required components for the enhanced UI:
 
 - Core: `button`, `card`, `badge`, `alert`, `dialog`, `input`, `label`
 - Data Display: `table`, `separator`, `collapsible`
-- Feedback: `toast` (via sonner), `tooltip`
+- Feedback: `error-dialog` for errors, `toast` (via sonner) for success/info, `tooltip`
 - Form: `form` (react-hook-form integration)
 
 ### Feature Components

--- a/components/auth-error-boundary.tsx
+++ b/components/auth-error-boundary.tsx
@@ -2,8 +2,8 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { toast } from "sonner";
 import { isAuthenticationError } from "@/lib/api/auth-interceptor";
+import { useErrorHandler } from "@/hooks/use-error-handler";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { AlertTriangleIcon, LogInIcon } from "lucide-react";
@@ -20,18 +20,13 @@ export function AuthErrorBoundary({
   children,
 }: AuthErrorBoundaryProps) {
   const router = useRouter();
+  const { handleError } = useErrorHandler();
 
   useEffect(() => {
     if (isAuthenticationError(error)) {
-      toast.error(`Authentication expired: ${error.provider}`, {
-        duration: 10000,
-        action: {
-          label: "Sign In",
-          onClick: () => router.push("/login"),
-        },
-      });
+      handleError(error, { stepTitle: "Authentication" });
     }
-  }, [error, router]);
+  }, [error, router, handleError]);
 
   if (isAuthenticationError(error)) {
     return (

--- a/components/auth.tsx
+++ b/components/auth.tsx
@@ -18,7 +18,7 @@ import {
   XCircleIcon,
 } from "lucide-react";
 import { signIn, useSession } from "next-auth/react";
-import { toast } from "sonner";
+import { useErrorHandler } from "@/hooks/use-error-handler";
 
 /**
  * Displays the connection status for each provider and triggers sign-in.
@@ -26,13 +26,14 @@ import { toast } from "sonner";
 export function AuthStatus() {
   const { data: session, status } = useSession();
   const { domain, tenantId } = useAppSelector((state) => state.appConfig);
+  const { handleError } = useErrorHandler();
 
   const isConfigReady = !!domain && !!tenantId;
   const isLoading = status === "loading";
 
   const handleSignIn = (provider: "google" | "microsoft-entra-id") => {
     if (!isConfigReady) {
-      toast.error("Please set the domain and tenant ID before connecting.");
+      handleError(new Error("Please set the domain and tenant ID before connecting."), { stepTitle: "Authentication" });
       return;
     }
     const options: { hd?: string; tenant?: string } = {};

--- a/components/error-toast-provider.tsx
+++ b/components/error-toast-provider.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { useEffect } from "react";
-import { toast } from "sonner";
+import { useErrorHandler } from "@/hooks/use-error-handler";
 
 export function ErrorToastProvider({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const { handleError } = useErrorHandler();
+
   useEffect(() => {
     const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
       console.error("Unhandled promise rejection:", event.reason);
@@ -16,10 +18,10 @@ export function ErrorToastProvider({
         event.reason?.message?.includes("API") &&
         event.reason?.message?.includes("not enabled")
       ) {
-        toast.error("Google Cloud API not enabled", {
-          description: "Check the console for details on which API to enable",
-          duration: 10000,
-        });
+        handleError(
+          new Error("Google Cloud API not enabled"),
+          { stepTitle: "Unhandled Rejection" },
+        );
       }
     };
 
@@ -30,7 +32,7 @@ export function ErrorToastProvider({
         handleUnhandledRejection,
       );
     };
-  }, []);
+  }, [handleError]);
 
   return <>{children}</>;
 }

--- a/components/modal-manager.tsx
+++ b/components/modal-manager.tsx
@@ -1,26 +1,37 @@
 "use client";
 
-import { useAppSelector } from "@/hooks/use-redux";
+import { useAppSelector, useAppDispatch } from "@/hooks/use-redux";
 import {
   selectStepDetailsModal,
   selectStepOutputsModal,
 } from "@/lib/redux/slices/modals";
-import { StepDetailsDialog } from "./step-details-dialog";
+import { selectActiveError, selectIsDismissible, dismissError } from "@/lib/redux/slices/errors";
+import { StepDetailsModal } from "./step-details-modal";
 import { StepOutputsDialog } from "./step-outputs-dialog";
+import { ErrorDialog } from "@/components/ui/error-dialog";
 
-/**
- * Centralized modal manager that renders all modals based on Redux state.
- * This component should be placed at the root level of the app.
- */
 export function ModalManager() {
+  const dispatch = useAppDispatch();
   const stepDetailsModal = useAppSelector(selectStepDetailsModal);
   const stepOutputsModal = useAppSelector(selectStepOutputsModal);
+  const activeError = useAppSelector(selectActiveError);
+  const isDismissible = useAppSelector(selectIsDismissible);
 
   return (
     <>
-      {stepDetailsModal.step && <StepDetailsDialog />}
-
+      {stepDetailsModal.step && <StepDetailsModal />}
       {stepOutputsModal.step && <StepOutputsDialog />}
+      {activeError && (
+        <ErrorDialog 
+          error={activeError}
+          open={!!activeError}
+          onOpenChange={(open) => {
+            if (!open && isDismissible) {
+              dispatch(dismissError());
+            }
+          }}
+        />
+      )}
     </>
   );
 }

--- a/components/step-details-modal.tsx
+++ b/components/step-details-modal.tsx
@@ -15,7 +15,7 @@ import { ExternalLinkIcon } from "lucide-react";
 import { useAppSelector, useAppDispatch } from "@/hooks/use-redux";
 import { selectStepDetailsModal, closeStepDetailsModal } from "@/lib/redux/slices/modals";
 
-export function StepDetailsDialog() {
+export function StepDetailsModal() {
   const dispatch = useAppDispatch();
   const { isOpen, step, outputs } = useAppSelector(selectStepDetailsModal);
 

--- a/hooks/use-error-handler.tsx
+++ b/hooks/use-error-handler.tsx
@@ -1,0 +1,69 @@
+import { useAppDispatch } from "./use-redux";
+import { showError } from "@/lib/redux/slices/errors";
+import { isAuthenticationError } from "@/lib/api/auth-interceptor";
+import { APIError } from "@/lib/api/utils";
+import { useRouter } from "next/navigation";
+import { LogInIcon, ExternalLinkIcon } from "lucide-react";
+
+export function useErrorHandler() {
+  const dispatch = useAppDispatch();
+  const router = useRouter();
+
+  const handleError = (error: unknown, context?: { stepId?: string; stepTitle?: string }) => {
+    if (isAuthenticationError(error)) {
+      dispatch(showError({
+        error: {
+          title: "Authentication Required",
+          message: `Your ${error.provider === "google" ? "Google Workspace" : "Microsoft"} session has expired.`,
+          code: "AUTH_EXPIRED",
+          provider: error.provider,
+          actions: [{
+            label: "Sign In",
+            onClick: () => router.push("/login"),
+            variant: "default",
+            icon: <LogInIcon className="mr-2 h-4 w-4" />
+          }]
+        },
+        dismissible: true
+      }));
+      return;
+    }
+
+    if (error instanceof APIError && error.code === "API_NOT_ENABLED") {
+      const enableUrlMatch = error.message?.match(
+        /https:\/\/console\.developers\.google\.com[^\s]+/,
+      );
+      const enableUrl = enableUrlMatch ? enableUrlMatch[0] : null;
+
+      dispatch(showError({
+        error: {
+          title: "Google Cloud API Not Enabled",
+          message: "Enable the required API to continue.",
+          code: "API_NOT_ENABLED",
+          details: { apiUrl: enableUrl },
+          actions: enableUrl ? [{
+            label: "Enable API",
+            onClick: () => window.open(enableUrl, "_blank"),
+            variant: "default",
+            icon: <ExternalLinkIcon className="mr-2 h-4 w-4" />
+          }] : []
+        },
+        dismissible: true
+      }));
+      return;
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    dispatch(showError({
+      error: {
+        title: context?.stepTitle ? `${context.stepTitle} Failed` : "Operation Failed",
+        message,
+        code: "UNKNOWN_ERROR",
+        details: context
+      },
+      dismissible: true
+    }));
+  };
+
+  return { handleError };
+}


### PR DESCRIPTION
## Summary
- add global ErrorDialog via `ModalManager`
- handle auth and API errors in `dashboard` with Redux-driven dialog
- provide reusable `use-error-handler` hook
- update error boundary logic to dispatch ErrorDialog
- rename step-details component and remove error toasts
- document new error handling approach

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68405e20c840832290214d6591d55edd