### PR TITLE
Update auth error handling and debug panel

### DIFF
--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -235,19 +235,19 @@ export function AutomationDashboard({
             showError({
               error: {
                 title: "Authentication Required",
-                message: `Your ${err.provider === "google" ? "Google Workspace" : "Microsoft"} session has expired.`,
+                message: err.message,
                 code: "AUTH_EXPIRED",
                 provider: err.provider,
                 actions: [
                   {
                     label: "Sign In",
                     onClick: () => router.push("/login"),
-                    variant: "default",
+                    variant: "default" as const,
                     icon: <LogInIcon className="mr-2 h-4 w-4" />,
                   },
                 ],
               },
-              dismissible: true,
+              dismissible: false,
             }),
           );
 
@@ -372,12 +372,12 @@ export function AutomationDashboard({
                   {
                     label: "Sign In",
                     onClick: () => router.push("/login"),
-                    variant: "default",
+                    variant: "default" as const,
                     icon: <LogInIcon className="mr-2 h-4 w-4" />,
                   },
                 ],
               },
-              dismissible: true,
+              dismissible: false,
             }),
           );
           dispatch(

--- a/components/debug-panel.tsx
+++ b/components/debug-panel.tsx
@@ -5,6 +5,7 @@ import {
   selectDebugPanel,
   selectFilteredLogs,
   toggleDebugPanel,
+  openDebugPanel,
   clearLogs,
   setFilter,
   type DebugPanelState,
@@ -22,7 +23,7 @@ import {
   AlertCircleIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   Collapsible,
   CollapsibleContent,
@@ -37,12 +38,9 @@ export function DebugPanel() {
   const logs = useAppSelector(selectFilteredLogs);
   const [expandedLogs, setExpandedLogs] = useState<Set<string>>(new Set());
 
-  if (
+  const debugDisabled =
     process.env.NODE_ENV !== "development" &&
-    !process.env.NEXT_PUBLIC_ENABLE_API_DEBUG
-  ) {
-    return null;
-  }
+    !process.env.NEXT_PUBLIC_ENABLE_API_DEBUG;
 
   const toggleLogExpansion = (id: string) => {
     setExpandedLogs((prev) => {
@@ -71,6 +69,18 @@ export function DebugPanel() {
   const errorCount = logs.filter(
     (log) => log.error || (log.responseStatus && log.responseStatus >= 400),
   ).length;
+
+  // Auto-open panel when there are errors
+  useEffect(() => {
+    if (debugDisabled) return;
+    if (errorCount > 0 && !isOpen) {
+      dispatch(openDebugPanel());
+    }
+  }, [errorCount, isOpen, dispatch, debugDisabled]);
+
+  if (debugDisabled) {
+    return null;
+  }
 
   if (!isOpen) {
     return (

--- a/components/progress.tsx
+++ b/components/progress.tsx
@@ -94,7 +94,7 @@ export function ProgressVisualizer({ onExecuteStep }: ProgressVisualizerProps) {
           </Card>
 
           <ScrollArea className="h-[calc(100vh-24rem)]">
-            <div className="grid gap-4 pr-4 grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 auto-rows-auto">
+            <div className="flex flex-col gap-4 pr-4 max-w-3xl mx-auto">
               {cat.steps.map((step) => (
                 <StepCard
                   key={step.id}

--- a/components/ui/error-dialog.tsx
+++ b/components/ui/error-dialog.tsx
@@ -84,9 +84,9 @@ export function ErrorDialog({
           <p>{error.message}</p>
           <div className="flex gap-2 justify-end">
             {hasActions ? (
-              error.actions!.map((action) => (
+              error.actions!.map((action, index) => (
                 <Button
-                  key={action.label}
+                  key={`${action.label}-${index}`}
                   onClick={() => {
                     action.onClick();
                     onOpenChange(false);

--- a/lib/api/microsoft.ts
+++ b/lib/api/microsoft.ts
@@ -475,7 +475,7 @@ export async function getSamlMetadata(
 ): Promise<SamlMetadata> {
   try {
     const url = microsoftAuthUrls.samlMetadata(tenantId, appId);
-    const res = await fetch(url);
+    const res = await fetchWithAuth(url, "");
     if (!res.ok) {
       throw new APIError(
         `Failed to fetch SAML metadata: ${res.statusText}`,

--- a/lib/redux/slices/debug-panel.ts
+++ b/lib/redux/slices/debug-panel.ts
@@ -14,6 +14,15 @@ export interface ApiLogEntry {
   provider?: "google" | "microsoft" | "other";
 }
 
+export interface AppErrorLogEntry {
+  id: string;
+  timestamp: string;
+  category: string;
+  message: string;
+  error?: string;
+  stackTrace?: string;
+}
+
 export interface DebugPanelState {
   isOpen: boolean;
   logs: ApiLogEntry[];
@@ -62,6 +71,20 @@ export const debugPanelSlice = createSlice({
         Object.assign(log, action.payload.updates);
       }
     },
+    addAppError(state, action: PayloadAction<Omit<AppErrorLogEntry, "id">>) {
+      const entry: ApiLogEntry = {
+        id: `error-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+        timestamp: action.payload.timestamp,
+        method: "ERROR",
+        url: action.payload.category,
+        error: action.payload.message,
+        provider: "other",
+      };
+      state.logs.unshift(entry);
+      if (state.logs.length > state.maxLogs) {
+        state.logs.pop();
+      }
+    },
   },
 });
 
@@ -70,6 +93,7 @@ export const {
   openDebugPanel,
   closeDebugPanel,
   addApiLog,
+  addAppError,
   clearLogs,
   setFilter,
   updateApiLog,

--- a/lib/steps/google/utils/error-handling.ts
+++ b/lib/steps/google/utils/error-handling.ts
@@ -1,5 +1,7 @@
 import { isAuthenticationError } from "@/lib/api/auth-interceptor";
 import { APIError } from "@/lib/api/utils";
+import { store } from "@/lib/redux/store";
+import { addAppError } from "@/lib/redux/slices/debug-panel";
 import type { StepCheckResult, StepExecutionResult } from "@/lib/types";
 
 export function handleCheckError(
@@ -7,6 +9,17 @@ export function handleCheckError(
   defaultMessage: string,
 ): StepCheckResult {
   console.error(`Check Action Error - ${defaultMessage}:`, error);
+
+  // Log to debug panel
+  store.dispatch(
+    addAppError({
+      timestamp: new Date().toISOString(),
+      category: "Check Error",
+      message: defaultMessage,
+      error: error instanceof Error ? error.message : String(error),
+      stackTrace: error instanceof Error ? error.stack : undefined,
+    }),
+  );
 
   if (isAuthenticationError(error)) {
     throw error; // Propagate auth errors to be handled by the UI

--- a/lib/steps/microsoft/utils/error-handling.ts
+++ b/lib/steps/microsoft/utils/error-handling.ts
@@ -1,5 +1,7 @@
 import { isAuthenticationError } from "@/lib/api/auth-interceptor";
 import { APIError } from "@/lib/api/utils";
+import { store } from "@/lib/redux/store";
+import { addAppError } from "@/lib/redux/slices/debug-panel";
 import type { StepCheckResult, StepExecutionResult } from "@/lib/types";
 
 export function handleCheckError(
@@ -7,6 +9,17 @@ export function handleCheckError(
   defaultMessage: string,
 ): StepCheckResult {
   console.error(`Check Action Error - ${defaultMessage}:`, error);
+
+  // Log to debug panel
+  store.dispatch(
+    addAppError({
+      timestamp: new Date().toISOString(),
+      category: "Check Error",
+      message: defaultMessage,
+      error: error instanceof Error ? error.message : String(error),
+      stackTrace: error instanceof Error ? error.stack : undefined,
+    }),
+  );
 
   if (isAuthenticationError(error)) {
     throw error;


### PR DESCRIPTION
## Summary
- simplify progress step layout to single column
- show sign in action on auth errors
- fix action mapping in error dialog
- auto-open debug panel on errors and support app error logs
- log check errors to the debug panel
- use `fetchWithAuth` for Microsoft SAML metadata requests

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684071f1e52c8322a7cd78772d172bea