### PR TITLE
Fix auth error logging and dialog actions

### DIFF
--- a/components/modal-manager.tsx
+++ b/components/modal-manager.tsx
@@ -9,9 +9,11 @@ import { selectActiveError, dismissError } from "@/lib/redux/slices/errors";
 import { StepDetailsModal } from "./step-details-modal";
 import { StepOutputsDialog } from "./step-outputs-dialog";
 import { ErrorDialog } from "@/components/ui/error-dialog";
+import { useRouter } from "next/navigation";
 
 export function ModalManager() {
   const dispatch = useAppDispatch();
+  const router = useRouter();
   const stepDetailsModal = useAppSelector(selectStepDetailsModal);
   const stepOutputsModal = useAppSelector(selectStepOutputsModal);
   const activeError = useAppSelector(selectActiveError);
@@ -22,14 +24,33 @@ export function ModalManager() {
     }
   };
 
+  const enhancedError = activeError
+    ? {
+        ...activeError,
+        actions: activeError.actions?.map((action) => ({
+          ...action,
+          onClick: () => {
+            if (action.label === "Sign In") {
+              router.push("/login");
+            } else if (
+              action.label === "Enable API" &&
+              activeError.details?.apiUrl
+            ) {
+              window.open(activeError.details.apiUrl as string, "_blank");
+            }
+          },
+        })),
+      }
+    : null;
+
   return (
     <>
       {stepDetailsModal.step && <StepDetailsModal />}
       {stepOutputsModal.step && <StepOutputsDialog />}
-      {activeError && (
+      {enhancedError && (
         <ErrorDialog
-          error={activeError}
-          open={!!activeError}
+          error={enhancedError}
+          open={!!enhancedError}
           onOpenChange={handleErrorDialogChange}
         />
       )}

--- a/components/progress.tsx
+++ b/components/progress.tsx
@@ -94,7 +94,7 @@ export function ProgressVisualizer({ onExecuteStep }: ProgressVisualizerProps) {
           </Card>
 
           <ScrollArea className="h-[calc(100vh-24rem)]">
-            <div className="flex flex-col gap-4 pr-4 max-w-3xl mx-auto">
+            <div className="flex flex-col gap-4 pr-4">
               {cat.steps.map((step) => (
                 <StepCard
                   key={step.id}

--- a/components/ui/error-dialog.tsx
+++ b/components/ui/error-dialog.tsx
@@ -46,7 +46,7 @@ export interface ErrorDialogProps {
     };
     actions?: Array<{
       label: string;
-      onClick: () => void;
+      onClick?: () => void;
       variant?: "default" | "outline" | "destructive";
       icon?: React.ReactNode;
     }>;
@@ -84,19 +84,28 @@ export function ErrorDialog({
           <p>{error.message}</p>
           <div className="flex gap-2 justify-end">
             {hasActions ? (
-              error.actions!.map((action, index) => (
-                <Button
-                  key={`${action.label}-${index}`}
-                  onClick={() => {
-                    action.onClick();
-                    onOpenChange(false);
-                  }}
-                  variant={action.variant || "default"}
-                >
-                  {action.icon}
-                  {action.label}
-                </Button>
-              ))
+              error.actions!.map((action, index) => {
+                console.log("Rendering action button:", action);
+                console.log("onClick type:", typeof action.onClick);
+                return (
+                  <Button
+                    key={`${action.label}-${index}`}
+                    onClick={() => {
+                      console.log("Button clicked, action:", action);
+                      if (typeof action.onClick === "function") {
+                        action.onClick();
+                      } else {
+                        console.error("onClick is not a function:", action);
+                      }
+                      onOpenChange(false);
+                    }}
+                    variant={action.variant || "default"}
+                  >
+                    {action.icon}
+                    {action.label}
+                  </Button>
+                );
+              })
             ) : (
               <Button onClick={() => onOpenChange(false)} variant="outline">
                 Dismiss

--- a/hooks/use-error-handler.tsx
+++ b/hooks/use-error-handler.tsx
@@ -2,12 +2,10 @@ import { useAppDispatch } from "./use-redux";
 import { showError } from "@/lib/redux/slices/errors";
 import { isAuthenticationError } from "@/lib/api/auth-interceptor";
 import { APIError } from "@/lib/api/utils";
-import { useRouter } from "next/navigation";
 import { LogInIcon, ExternalLinkIcon } from "lucide-react";
 
 export function useErrorHandler() {
   const dispatch = useAppDispatch();
-  const router = useRouter();
 
   const handleError = (
     error: unknown,
@@ -24,7 +22,6 @@ export function useErrorHandler() {
             actions: [
               {
                 label: "Sign In",
-                onClick: () => router.push("/login"),
                 variant: "default",
                 icon: <LogInIcon className="mr-2 h-4 w-4" />,
               },
@@ -53,7 +50,6 @@ export function useErrorHandler() {
               ? [
                   {
                     label: "Enable API",
-                    onClick: () => window.open(enableUrl, "_blank"),
                     variant: "default",
                     icon: <ExternalLinkIcon className="mr-2 h-4 w-4" />,
                   },

--- a/lib/steps/google/utils/error-handling.ts
+++ b/lib/steps/google/utils/error-handling.ts
@@ -1,7 +1,7 @@
 import { isAuthenticationError } from "@/lib/api/auth-interceptor";
 import { APIError } from "@/lib/api/utils";
 import { store } from "@/lib/redux/store";
-import { addAppError } from "@/lib/redux/slices/debug-panel";
+import { addAppError, addApiLog } from "@/lib/redux/slices/debug-panel";
 import type { StepCheckResult, StepExecutionResult } from "@/lib/types";
 
 export function handleCheckError(
@@ -22,6 +22,17 @@ export function handleCheckError(
   );
 
   if (isAuthenticationError(error)) {
+    // Log authentication errors before throwing so they appear in the debug panel
+    store.dispatch(
+      addApiLog({
+        id: `auth-error-${Date.now()}`,
+        timestamp: new Date().toISOString(),
+        method: "AUTH_ERROR",
+        url: error.provider || "unknown",
+        error: `Authentication Error: ${error.message}`,
+        provider: error.provider === "google" ? "google" : "microsoft",
+      }),
+    );
     throw error; // Propagate auth errors to be handled by the UI
   }
 

--- a/lib/steps/microsoft/utils/error-handling.ts
+++ b/lib/steps/microsoft/utils/error-handling.ts
@@ -1,7 +1,7 @@
 import { isAuthenticationError } from "@/lib/api/auth-interceptor";
 import { APIError } from "@/lib/api/utils";
 import { store } from "@/lib/redux/store";
-import { addAppError } from "@/lib/redux/slices/debug-panel";
+import { addAppError, addApiLog } from "@/lib/redux/slices/debug-panel";
 import type { StepCheckResult, StepExecutionResult } from "@/lib/types";
 
 export function handleCheckError(
@@ -22,6 +22,17 @@ export function handleCheckError(
   );
 
   if (isAuthenticationError(error)) {
+    // Log authentication errors before throwing so they appear in the debug panel
+    store.dispatch(
+      addApiLog({
+        id: `auth-error-${Date.now()}`,
+        timestamp: new Date().toISOString(),
+        method: "AUTH_ERROR",
+        url: error.provider || "unknown",
+        error: `Authentication Error: ${error.message}`,
+        provider: error.provider === "google" ? "google" : "microsoft",
+      }),
+    );
     throw error;
   }
 


### PR DESCRIPTION
## Summary
- log auth errors before throwing so they appear in debug panel
- store error dialog actions without functions
- resolve error dialog actions in ModalManager
- add debugging to ErrorDialog
- adjust Progress cards width

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6840783bf1c08322b49d42af4b93118c