### PR TITLE
Improve Redux error handling

### DIFF
--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { AlertTriangleIcon, HomeIcon, RefreshCwIcon } from "lucide-react";
 import { isAuthenticationError } from "@/lib/api/auth-interceptor";
+import { ErrorActionType } from "@/lib/redux/slices/errors";
 
 export default function GlobalError({
   error,

--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -16,7 +16,7 @@ import { useStore } from "react-redux";
 import { toast } from "sonner";
 
 import { useAppDispatch, useAppSelector } from "@/hooks/use-redux";
-import { showError } from "@/lib/redux/slices/errors";
+import { showError, ErrorActionType } from "@/lib/redux/slices/errors";
 import { APIError } from "@/lib/api/utils";
 import {
   loadProgress,
@@ -240,10 +240,10 @@ export function AutomationDashboard({
                 provider: err.provider,
                 actions: [
                   {
+                    type: ErrorActionType.SIGN_IN,
                     label: "Sign In",
-                    onClick: () => router.push("/login"),
-                    variant: "default" as const,
-                    icon: <LogInIcon className="mr-2 h-4 w-4" />,
+                    variant: "default",
+                    icon: "LogInIcon",
                   },
                 ],
               },
@@ -284,10 +284,11 @@ export function AutomationDashboard({
                 actions: enableUrl
                   ? [
                       {
+                        type: ErrorActionType.ENABLE_API,
                         label: "Enable API",
-                        onClick: () => window.open(enableUrl, "_blank"),
                         variant: "default",
-                        icon: <ExternalLinkIcon className="mr-2 h-4 w-4" />,
+                        icon: "ExternalLinkIcon",
+                        payload: { url: enableUrl },
                       },
                     ]
                   : [],
@@ -370,10 +371,10 @@ export function AutomationDashboard({
                   | "microsoft",
                 actions: [
                   {
+                    type: ErrorActionType.SIGN_IN,
                     label: "Sign In",
-                    onClick: () => router.push("/login"),
-                    variant: "default" as const,
-                    icon: <LogInIcon className="mr-2 h-4 w-4" />,
+                    variant: "default",
+                    icon: "LogInIcon",
                   },
                 ],
               },
@@ -431,10 +432,11 @@ export function AutomationDashboard({
                   actions: enableUrl
                     ? [
                         {
+                          type: ErrorActionType.ENABLE_API,
                           label: "Enable API",
-                          onClick: () => window.open(enableUrl, "_blank"),
                           variant: "default",
-                          icon: <ExternalLinkIcon className="mr-2 h-4 w-4" />,
+                          icon: "ExternalLinkIcon",
+                          payload: { url: enableUrl },
                         },
                       ]
                     : [],

--- a/components/modal-manager.tsx
+++ b/components/modal-manager.tsx
@@ -5,15 +5,13 @@ import {
   selectStepDetailsModal,
   selectStepOutputsModal,
 } from "@/lib/redux/slices/modals";
-import { selectActiveError, dismissError } from "@/lib/redux/slices/errors";
+import { selectActiveError, dismissError, ErrorActionType } from "@/lib/redux/slices/errors";
 import { StepDetailsModal } from "./step-details-modal";
 import { StepOutputsDialog } from "./step-outputs-dialog";
 import { ErrorDialog } from "@/components/ui/error-dialog";
-import { useRouter } from "next/navigation";
 
 export function ModalManager() {
   const dispatch = useAppDispatch();
-  const router = useRouter();
   const stepDetailsModal = useAppSelector(selectStepDetailsModal);
   const stepOutputsModal = useAppSelector(selectStepOutputsModal);
   const activeError = useAppSelector(selectActiveError);
@@ -24,33 +22,14 @@ export function ModalManager() {
     }
   };
 
-  const enhancedError = activeError
-    ? {
-        ...activeError,
-        actions: activeError.actions?.map((action) => ({
-          ...action,
-          onClick: () => {
-            if (action.label === "Sign In") {
-              router.push("/login");
-            } else if (
-              action.label === "Enable API" &&
-              activeError.details?.apiUrl
-            ) {
-              window.open(activeError.details.apiUrl as string, "_blank");
-            }
-          },
-        })),
-      }
-    : null;
-
   return (
     <>
       {stepDetailsModal.step && <StepDetailsModal />}
       {stepOutputsModal.step && <StepOutputsDialog />}
-      {enhancedError && (
+      {activeError && (
         <ErrorDialog
-          error={enhancedError}
-          open={!!enhancedError}
+          error={activeError}
+          open={!!activeError}
           onOpenChange={handleErrorDialogChange}
         />
       )}

--- a/hooks/use-error-actions.tsx
+++ b/hooks/use-error-actions.tsx
@@ -1,0 +1,63 @@
+import { useRouter } from "next/navigation";
+import { useAppDispatch } from "./use-redux";
+import { dismissError, ErrorActionType, type ErrorAction } from "@/lib/redux/slices/errors";
+import {
+  LogInIcon,
+  ExternalLinkIcon,
+  RefreshCwIcon,
+  AlertCircleIcon,
+  XIcon,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+const iconMap: Record<string, LucideIcon> = {
+  LogInIcon,
+  ExternalLinkIcon,
+  RefreshCwIcon,
+  AlertCircleIcon,
+  XIcon,
+};
+
+export function useErrorActions() {
+  const router = useRouter();
+  const dispatch = useAppDispatch();
+
+  const resolveAction = (action: ErrorAction): {
+    label: string;
+    variant?: "default" | "outline" | "destructive";
+    icon?: React.ReactNode;
+    onClick: () => void;
+  } => {
+    const Icon = action.icon ? iconMap[action.icon] : undefined;
+
+    return {
+      label: action.label,
+      variant: action.variant,
+      icon: Icon ? <Icon className="mr-2 h-4 w-4" /> : undefined,
+      onClick: () => {
+        switch (action.type) {
+          case ErrorActionType.SIGN_IN:
+            dispatch(dismissError());
+            router.push("/login");
+            break;
+          case ErrorActionType.OPEN_URL:
+          case ErrorActionType.ENABLE_API:
+            if (action.payload?.url) {
+              window.open(action.payload.url as string, "_blank");
+            }
+            dispatch(dismissError());
+            break;
+          case ErrorActionType.RETRY_STEP:
+            dispatch(dismissError());
+            break;
+          case ErrorActionType.DISMISS:
+          default:
+            dispatch(dismissError());
+            break;
+        }
+      },
+    };
+  };
+
+  return { resolveAction };
+}

--- a/hooks/use-error-handler.tsx
+++ b/hooks/use-error-handler.tsx
@@ -1,8 +1,7 @@
 import { useAppDispatch } from "./use-redux";
-import { showError } from "@/lib/redux/slices/errors";
+import { showError, ErrorActionType } from "@/lib/redux/slices/errors";
 import { isAuthenticationError } from "@/lib/api/auth-interceptor";
 import { APIError } from "@/lib/api/utils";
-import { LogInIcon, ExternalLinkIcon } from "lucide-react";
 
 export function useErrorHandler() {
   const dispatch = useAppDispatch();
@@ -21,9 +20,10 @@ export function useErrorHandler() {
             provider: error.provider,
             actions: [
               {
+                type: ErrorActionType.SIGN_IN,
                 label: "Sign In",
                 variant: "default",
-                icon: <LogInIcon className="mr-2 h-4 w-4" />,
+                icon: "LogInIcon",
               },
             ],
           },
@@ -49,9 +49,11 @@ export function useErrorHandler() {
             actions: enableUrl
               ? [
                   {
+                    type: ErrorActionType.ENABLE_API,
                     label: "Enable API",
                     variant: "default",
-                    icon: <ExternalLinkIcon className="mr-2 h-4 w-4" />,
+                    icon: "ExternalLinkIcon",
+                    payload: { url: enableUrl },
                   },
                 ]
               : [],


### PR DESCRIPTION
## Summary
- refactor Redux error slice to store serializable descriptors
- add new hook to resolve error actions
- update error dialog to use resolver
- add simplified error boundary and handler
- clean up modal manager implementation

## Testing
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68407e38a2608322bfcfaebd3a2e2da7