### PR TITLE
Improve auth error handling and auto-check logging

### DIFF
--- a/app/(auth)/auth.ts
+++ b/app/(auth)/auth.ts
@@ -27,6 +27,20 @@ function getUserKey(_userOrToken?: User | JWT): string {
  */
 async function refreshGoogleToken(token: JWT): Promise<JWT> {
   try {
+    Logger.debug(
+      "[Auth]",
+      "Attempting to refresh Google token. Has refresh token:",
+      !!token.googleRefreshToken,
+    );
+
+    if (!token.googleRefreshToken) {
+      Logger.error("[Auth]", "Google refresh token is missing. Cannot refresh.");
+      return {
+        ...token,
+        error: "RefreshTokenError",
+        googleAccessToken: undefined,
+      };
+    }
     const response = await fetch(googleOAuthUrls.token(), {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -39,7 +53,13 @@ async function refreshGoogleToken(token: JWT): Promise<JWT> {
     });
     const refreshed = await response.json();
     if (!response.ok) {
-      Logger.error("[Auth]", "Google token refresh API error", refreshed);
+      Logger.error(
+        "[Auth]",
+        "Google token refresh API error. Status:",
+        response.status,
+        "Body:",
+        refreshed,
+      );
       throw refreshed;
     }
     return {
@@ -392,7 +412,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           } else if (!finalToken.error) {
             Logger.error(
               "[Auth]",
-              "Google token expired but no refresh token available",
+              "Google token expired AND no refresh token available. Marking RefreshTokenError.",
             );
             finalToken.error = "RefreshTokenError";
             finalToken.googleAccessToken = undefined;

--- a/app/actions/step-actions.ts
+++ b/app/actions/step-actions.ts
@@ -15,17 +15,9 @@ export async function executeStepCheck(
   try {
     return await checkStep(stepId, context);
   } catch (error) {
-    // For authentication errors, return a proper StepCheckResult instead of throwing
+    // Bubble up authentication errors for global handlers
     if (isAuthenticationError(error)) {
-      return {
-        completed: false,
-        message: error.message,
-        outputs: {
-          errorCode: "AUTH_EXPIRED",
-          errorProvider: error.provider,
-          errorMessage: error.message,
-        },
-      };
+      throw error;
     }
 
     // For other errors, convert to StepCheckResult

--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -221,13 +221,13 @@ export function AutomationDashboard({
               },
             }),
           );
-          // toast.error(
-          //   `${definition.title}: ${result.error?.message ?? "Failed"}`,
-          //   {
-          //     id: toastId,
-          //     duration: 10000,
-          //   },
-          // );
+          toast.error(
+            `${definition.title}: ${result.error?.message ?? "Failed"}`,
+            {
+              id: toastId,
+              duration: 10000,
+            },
+          );
         }
       } catch (err) {
         if (isAuthenticationError(err)) {

--- a/hooks/use-auto-check.ts
+++ b/hooks/use-auto-check.ts
@@ -34,13 +34,22 @@ export function useAutoCheck(
       if (hasChecked.current || isValidating) return;
 
       // Skip if config not ready
-      if (!appConfig.domain || !appConfig.tenantId) return;
+      if (!appConfig.domain || !appConfig.tenantId) {
+        Logger.info("[Hook]", "Skipping auto-check: domain or tenantId missing");
+        return;
+      }
 
       // Skip if session is still loading
-      if (status === "loading") return;
+      if (status === "loading") {
+        Logger.info("[Hook]", "Skipping auto-check: session loading");
+        return;
+      }
 
       // Skip if session not ready
-      if (!session?.hasGoogleAuth || !session?.hasMicrosoftAuth) return;
+      if (!session?.hasGoogleAuth || !session?.hasMicrosoftAuth) {
+        Logger.info("[Hook]", "Skipping auto-check: session not authenticated");
+        return;
+      }
 
       // Check for existing auth errors
       const authErrorPresent = Object.values(stepsStatus).some(
@@ -71,7 +80,7 @@ export function useAutoCheck(
         if (session.error === "RefreshTokenError") {
           Logger.warn(
             "[Hook]",
-            "Session has refresh token error, skipping auto-check",
+            "Skipping auto-check: RefreshTokenError present",
           );
           setIsValidating(false);
           return;


### PR DESCRIPTION
## Summary
- bubble up `AuthenticationError` in `executeStepCheck`
- use consistent toast IDs for step execution toasts
- enhance Google token refresh logging and handling
- add skip reason logs in `useAutoCheck`

## Testing
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_684083104f3c8322a715a5d0cdf3467e