### PR TITLE
Improve auth error handling

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -74,6 +74,26 @@ function LoginPage() {
     }
   }, [searchParams]);
 
+  // Handle auth errors from redirects
+  useEffect(() => {
+    const authAttempt = searchParams.get("authAttempt");
+    const error = searchParams.get("error");
+
+    if (authAttempt && !error && sessionStatus === "authenticated") {
+      if (authAttempt === "google" && !session?.hasGoogleAuth) {
+        toast.error("Google authentication failed. Please try again.", {
+          id: "google-auth-failed",
+          duration: 10000,
+        });
+      } else if (authAttempt === "microsoft" && !session?.hasMicrosoftAuth) {
+        toast.error("Microsoft authentication failed. Please try again.", {
+          id: "microsoft-auth-failed",
+          duration: 10000,
+        });
+      }
+    }
+  }, [searchParams, session, sessionStatus]);
+
   const handleDomainChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setDomain(e.target.value);
     setIsTenantDiscovered(false);

--- a/hooks/use-auto-check.ts
+++ b/hooks/use-auto-check.ts
@@ -1,13 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useAppSelector } from "./use-redux";
-import { useSessionSync } from "./use-session-sync";
 import { Logger } from "@/lib/utils/logger";
 
 /**
- * Runs lightweight `check` functions after configuration becomes available.
- *
- * @param executeCheck - Callback executed for each step needing a check
- * @returns void
+ * Automatically runs step checks once configuration is available.
+ * Only executes lightweight check functions for predefined steps.
  */
 export function useAutoCheck(
   executeCheck: (stepId: string) => Promise<void>,
@@ -15,129 +12,40 @@ export function useAutoCheck(
   const appConfig = useAppSelector((state) => state.appConfig);
   const stepsStatus = useAppSelector((state) => state.setupSteps.steps);
   const hasChecked = useRef(false);
-  const [isValidating, setIsValidating] = useState(false);
-  const { session, status } = useSessionSync();
-  const checkTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  // Reset when domain changes
+  const runChecks = useCallback(async () => {
+    if (hasChecked.current) return;
+    if (!appConfig.domain || !appConfig.tenantId) return;
+
+    hasChecked.current = true;
+    Logger.info("[Hook]", "Running auto-checks for steps");
+
+    const autoCheckSteps = ["G-4", "G-5", "M-1", "M-6"];
+
+    for (const stepId of autoCheckSteps) {
+      const status = stepsStatus[stepId];
+
+      if (status?.status === "completed") {
+        continue;
+      }
+
+      try {
+        await executeCheck(stepId);
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      } catch (error) {
+        Logger.error("[Hook]", `Check failed for ${stepId}`, error);
+      }
+    }
+  }, [appConfig.domain, appConfig.tenantId, stepsStatus, executeCheck]);
+
   useEffect(() => {
     hasChecked.current = false;
   }, [appConfig.domain]);
 
-  // Debounced check function
-  const debouncedCheck = useCallback(() => {
-    if (checkTimeoutRef.current) {
-      clearTimeout(checkTimeoutRef.current);
-    }
-    checkTimeoutRef.current = setTimeout(async () => {
-      // Skip if already checking
-      if (hasChecked.current || isValidating) return;
-
-      // Skip if config not ready
-      if (!appConfig.domain || !appConfig.tenantId) return;
-
-      // Skip if session is still loading
-      if (status === "loading") return;
-
-      // Skip if session not ready
-      if (!session?.hasGoogleAuth || !session?.hasMicrosoftAuth) return;
-
-      // Check for existing auth errors
-      const authErrorPresent = Object.values(stepsStatus).some(
-        (s) => s.metadata?.errorCode === "AUTH_EXPIRED",
-      );
-      if (authErrorPresent) {
-        Logger.info(
-          "[Hook]",
-          "Skipping auto-check due to existing auth errors",
-        );
-        return;
-      }
-
-      setIsValidating(true);
-
-      try {
-        // Check if session has required tokens
-        if (!session.googleToken || !session.microsoftToken) {
-          Logger.warn(
-            "[Hook]",
-            "Session missing required tokens, skipping auto-check",
-          );
-          setIsValidating(false);
-          return;
-        }
-
-        // Check for refresh token error
-        if (session.error === "RefreshTokenError") {
-          Logger.warn(
-            "[Hook]",
-            "Session has refresh token error, skipping auto-check",
-          );
-          setIsValidating(false);
-          return;
-        }
-
-        hasChecked.current = true;
-
-        // Only check steps that:
-        // 1. Are automatable
-        // 2. Have check functions
-        // 3. Are not already completed (unless they failed with non-auth error)
-        const autoCheckSteps = ["G-4", "G-5", "M-1", "M-6"];
-
-        for (const stepId of autoCheckSteps) {
-          const status = stepsStatus[stepId];
-
-          // Skip if already successfully completed
-          if (status?.status === "completed" && !status.metadata?.errorCode) {
-            continue;
-          }
-
-          // Skip if failed with auth error (needs manual re-auth)
-          if (status?.metadata?.errorCode === "AUTH_EXPIRED") {
-            continue;
-          }
-
-          try {
-            await executeCheck(stepId);
-            // Add small delay between checks to avoid rate limiting
-            await new Promise((resolve) => setTimeout(resolve, 500));
-          } catch (error) {
-            Logger.error("[Hook]", `Check failed for ${stepId}`, error);
-            // Continue with other checks even if one fails
-          }
-        }
-      } catch (error) {
-        Logger.error("[Hook]", "Auto-check error", error);
-      } finally {
-        setIsValidating(false);
-      }
-    }, 2000);
-  }, [appConfig, stepsStatus, session, status, executeCheck, isValidating]);
-
-  // Trigger debounced check when dependencies change
   useEffect(() => {
-    if (
-      appConfig.domain &&
-      appConfig.tenantId &&
-      session?.hasGoogleAuth &&
-      session?.hasMicrosoftAuth &&
-      status === "authenticated"
-    ) {
-      debouncedCheck();
+    if (appConfig.domain && appConfig.tenantId) {
+      const timer = setTimeout(runChecks, 1000);
+      return () => clearTimeout(timer);
     }
-
-    return () => {
-      if (checkTimeoutRef.current) {
-        clearTimeout(checkTimeoutRef.current);
-      }
-    };
-  }, [
-    appConfig.domain,
-    appConfig.tenantId,
-    session?.hasGoogleAuth,
-    session?.hasMicrosoftAuth,
-    status,
-    debouncedCheck,
-  ]);
+  }, [appConfig.domain, appConfig.tenantId, runChecks]);
 }


### PR DESCRIPTION
## Summary
- simplify auto-check hook
- enhance dashboard step execution/check error handling
- surface redirect auth errors on login page
- add session validation to step server actions

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684083e0e4d883228e341052d846f070