### PR TITLE
Add debug panel nub

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css";
 import { Providers } from "./providers";
 import { ModalManager } from "@/components/modal-manager";
 import { DebugPanel } from "@/components/debug-panel";
+import { DebugPanelNub } from "@/components/debug-panel-nub";
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertTriangleIcon } from "lucide-react";
@@ -56,6 +57,7 @@ export default function RootLayout({
         <Providers>
           {children}
           <ModalManager />
+          <DebugPanelNub />
           <DebugPanel />
           <Toaster richColors />
         </Providers>

--- a/components/debug-panel-nub-minimal.tsx
+++ b/components/debug-panel-nub-minimal.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import { useAppSelector, useAppDispatch } from "@/hooks/use-redux"
+import { toggleDebugPanel, selectFilteredLogs } from "@/lib/redux/slices/debug-panel"
+import { cn } from "@/lib/utils"
+import { BugIcon } from "lucide-react"
+
+export function DebugPanelNubMinimal() {
+  const dispatch = useAppDispatch()
+  const isOpen = useAppSelector((state) => state.debugPanel.isOpen)
+  const logs = useAppSelector(selectFilteredLogs)
+
+  const debugDisabled = !process.env.NEXT_PUBLIC_ENABLE_API_DEBUG
+
+  if (debugDisabled) {
+    return null
+  }
+
+  const errorCount = logs.filter(
+    (log) => log.error || (log.responseStatus && log.responseStatus >= 400)
+  ).length
+
+  return (
+    <button
+      onClick={() => dispatch(toggleDebugPanel())}
+      className={cn(
+        "fixed bottom-0 left-1/2 -translate-x-1/2 z-[60]",
+        "bg-primary text-primary-foreground",
+        "px-4 py-1 rounded-t-md",
+        "hover:bg-primary/90 transition-all duration-200",
+        "flex items-center gap-2",
+        "shadow-lg hover:shadow-xl",
+        "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+        isOpen && "opacity-0 pointer-events-none",
+        errorCount > 0 && "bg-destructive hover:bg-destructive/90 animate-pulse"
+      )}
+    >
+      <BugIcon className="h-3 w-3" />
+      <span className="text-xs font-medium">
+        {errorCount > 0 ? `${errorCount} errors` : `${logs.length} logs`}
+      </span>
+    </button>
+  )
+}
+

--- a/components/debug-panel-nub-side.tsx
+++ b/components/debug-panel-nub-side.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { useAppSelector, useAppDispatch } from "@/hooks/use-redux"
+import { toggleDebugPanel, selectFilteredLogs } from "@/lib/redux/slices/debug-panel"
+import { Badge } from "@/components/ui/badge"
+import { cn } from "@/lib/utils"
+import { BugIcon, ChevronLeft } from "lucide-react"
+
+export function DebugPanelNubSide() {
+  const dispatch = useAppDispatch()
+  const isOpen = useAppSelector((state) => state.debugPanel.isOpen)
+  const logs = useAppSelector(selectFilteredLogs)
+
+  const debugDisabled = !process.env.NEXT_PUBLIC_ENABLE_API_DEBUG
+
+  if (debugDisabled) {
+    return null
+  }
+
+  const errorCount = logs.filter(
+    (log) => log.error || (log.responseStatus && log.responseStatus >= 400)
+  ).length
+
+  return (
+    <button
+      onClick={() => dispatch(toggleDebugPanel())}
+      className={cn(
+        "fixed right-0 bottom-20 z-[60]",
+        "bg-background border border-r-0 rounded-l-md",
+        "px-2 py-4 shadow-lg",
+        "hover:bg-accent transition-all duration-200",
+        "flex flex-col items-center gap-2",
+        "writing-mode-vertical-lr",
+        isOpen && "opacity-0 pointer-events-none",
+        errorCount > 0 && "border-destructive animate-pulse"
+      )}
+      style={{ writingMode: "vertical-lr" }}
+    >
+      <ChevronLeft className="h-3 w-3 rotate-90" />
+      <span className="text-xs font-medium">API Debug</span>
+      {errorCount > 0 && (
+        <Badge variant="destructive" className="h-4 w-4 p-0 text-[10px]">
+          {errorCount}
+        </Badge>
+      )}
+    </button>
+  )
+}
+

--- a/components/debug-panel-nub.tsx
+++ b/components/debug-panel-nub.tsx
@@ -1,0 +1,91 @@
+"use client"
+
+import { useAppSelector, useAppDispatch } from "@/hooks/use-redux"
+import { toggleDebugPanel, selectFilteredLogs } from "@/lib/redux/slices/debug-panel"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import { ChevronUp, BugIcon } from "lucide-react"
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
+
+export function DebugPanelNub() {
+  const dispatch = useAppDispatch()
+  const isOpen = useAppSelector((state) => state.debugPanel.isOpen)
+  const logs = useAppSelector(selectFilteredLogs)
+
+  const debugDisabled = !process.env.NEXT_PUBLIC_ENABLE_API_DEBUG
+
+  if (debugDisabled) {
+    return null
+  }
+
+  const errorCount = logs.filter(
+    (log) => log.error || (log.responseStatus && log.responseStatus >= 400)
+  ).length
+
+  const pendingCount = logs.filter(
+    (log) => !log.responseStatus && !log.error
+  ).length
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            className={cn(
+              "fixed bottom-0 left-1/2 -translate-x-1/2 z-[60] transition-all duration-300",
+              isOpen && "pointer-events-none opacity-0"
+            )}
+          >
+            <Button
+              onClick={() => dispatch(toggleDebugPanel())}
+              variant="outline"
+              size="sm"
+              className={cn(
+                "rounded-t-md rounded-b-none border-b-0 px-6 py-1 h-7",
+                "bg-background/95 backdrop-blur-sm shadow-lg",
+                "hover:bg-accent hover:shadow-xl",
+                "transition-all duration-200",
+                errorCount > 0 && "border-destructive/50 animate-pulse"
+              )}
+            >
+              <div className="flex items-center gap-2">
+                <BugIcon className="h-3 w-3" />
+                <span className="text-xs font-medium">API Debug</span>
+                {(errorCount > 0 || pendingCount > 0 || logs.length > 0) && (
+                  <div className="flex items-center gap-1">
+                    {errorCount > 0 && (
+                      <Badge variant="destructive" className="h-4 px-1 text-[10px]">
+                        {errorCount}
+                      </Badge>
+                    )}
+                    {pendingCount > 0 && (
+                      <Badge variant="secondary" className="h-4 px-1 text-[10px]">
+                        {pendingCount}
+                      </Badge>
+                    )}
+                    {errorCount === 0 && pendingCount === 0 && logs.length > 0 && (
+                      <Badge variant="outline" className="h-4 px-1 text-[10px]">
+                        {logs.length}
+                      </Badge>
+                    )}
+                  </div>
+                )}
+                <ChevronUp className="h-3 w-3 ml-1" />
+              </div>
+            </Button>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="p-2 max-w-xs">
+          <div className="text-xs space-y-1">
+            <div>Total Requests: {logs.length}</div>
+            {errorCount > 0 && <div className="text-destructive">Errors: {errorCount}</div>}
+            {pendingCount > 0 && <div className="text-blue-500">Pending: {pendingCount}</div>}
+            <div className="text-muted-foreground mt-1">Click to open debug panel</div>
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+

--- a/components/debug-panel.tsx
+++ b/components/debug-panel.tsx
@@ -25,7 +25,6 @@ import {
 import { cn } from "@/lib/utils"
 import { ApiLogCard } from "./api-log-card"
 import { toast } from "sonner"
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import { useEffect } from "react"
 
 export function DebugPanel() {
@@ -59,46 +58,13 @@ export function DebugPanel() {
     return () => window.removeEventListener('keydown', handleKeyPress)
   }, [dispatch])
 
-  if (debugDisabled) {
+  if (debugDisabled || !isOpen) {
     return null
   }
 
   const showProdWarning =
     process.env.NODE_ENV === "production" &&
     process.env.NEXT_PUBLIC_ENABLE_API_DEBUG
-
-  if (!isOpen) {
-    return (
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              onClick={() => dispatch(toggleDebugPanel())}
-              size="icon"
-              className={cn(
-                "fixed bottom-4 right-4 z-50 h-14 w-14 rounded-full shadow-lg",
-                errorCount > 0 && "animate-pulse"
-              )}
-              variant={errorCount > 0 ? "destructive" : "default"}
-            >
-              <BugIcon className="h-6 w-6" />
-              {errorCount > 0 && (
-                <Badge 
-                  className="absolute -top-1 -right-1 h-6 w-6 p-0 flex items-center justify-center"
-                  variant="destructive"
-                >
-                  {errorCount}
-                </Badge>
-              )}
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="left">
-            <p>API Debug Panel {errorCount > 0 && `(${errorCount} errors)`}</p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-    )
-  }
 
   return (
     <div className="fixed bottom-0 left-0 right-0 z-50 h-[60vh] flex flex-col bg-background border-t shadow-2xl">


### PR DESCRIPTION
## Summary
- add debug-panel-nub with tooltip preview
- provide optional minimal and side variants
- update main DebugPanel to remove floating button
- show nub and panel in layout

## Testing
- `pnpm test:build`
- `pnpm test:runtime`


------
https://chatgpt.com/codex/tasks/task_e_6840f453891c8322a3f1574badcddeeb