### PR TITLE
Fix auto-check and progress persistence

### DIFF
--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -5,6 +5,7 @@ import {
   Loader2Icon,
   PlayIcon,
   LogInIcon,
+  RefreshCw,
 } from "lucide-react";
 import type { Session } from "next-auth";
 import { signOut } from "next-auth/react";
@@ -319,13 +320,46 @@ export function AutomationDashboard({
     ).length;
     const progressPercent = (completedSteps / totalSteps) * 100;
 
+    const refreshChecks = useCallback(async () => {
+      if (!canRunAutomation) {
+        return;
+      }
+      toast.info("Refreshing step status...", { duration: 2000 });
+
+      // Get all checkable steps
+      const checkableSteps = allStepDefinitions
+        .filter((step) => step.check !== undefined)
+        .map((step) => step.id as StepId);
+
+      for (const stepId of checkableSteps) {
+        await executeCheck(stepId);
+        await new Promise((resolve) => setTimeout(resolve, 300));
+      }
+
+      toast.success("Status refreshed", { duration: 2000 });
+    }, [canRunAutomation, executeCheck]);
+
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Progress</CardTitle>
-          <CardDescription>
-            {completedSteps}/{totalSteps} done
-          </CardDescription>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>Progress</CardTitle>
+              <CardDescription>
+                {completedSteps}/{totalSteps} done
+              </CardDescription>
+            </div>
+            {canRunAutomation && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={refreshChecks}
+                title="Refresh status from server"
+              >
+                <RefreshCw className="h-4 w-4" />
+              </Button>
+            )}
+          </div>
         </CardHeader>
         <CardContent className="space-y-4">
           <Progress value={progressPercent} className="h-3" />

--- a/hooks/use-auto-check.ts
+++ b/hooks/use-auto-check.ts
@@ -1,39 +1,34 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect } from "react";
 import { useAppSelector } from "./use-redux";
 import { Logger } from "@/lib/utils/logger";
-import { STEP_IDS } from "@/lib/steps/step-refs";
 import type { StepId } from "@/lib/steps/step-refs";
+import { allStepDefinitions } from "@/lib/steps";
 
 /**
- * Automatically runs step checks once configuration is available.
- * Only executes lightweight check functions for predefined steps.
+ * Automatically runs step checks when configuration is available.
+ * Only executes for steps that have a check function defined.
  */
 export function useAutoCheck(
   executeCheck: (stepId: StepId) => Promise<void>,
 ): void {
   const appConfig = useAppSelector((state) => state.appConfig);
   const stepsStatus = useAppSelector((state) => state.setupSteps.steps);
-  const hasChecked = useRef(false);
 
   const runChecks = useCallback(async () => {
-    if (hasChecked.current) return;
     if (!appConfig.domain || !appConfig.tenantId) return;
 
-    hasChecked.current = true;
-    Logger.info("[Hook]", "Running auto-checks for steps");
+    Logger.info("[Hook]", "Running auto-checks for checkable steps");
 
-    const autoCheckSteps = [
-      STEP_IDS.CREATE_AUTOMATION_OU,
-      STEP_IDS.VERIFY_DOMAIN,
-      STEP_IDS.INITIATE_SAML_PROFILE,
-      STEP_IDS.CREATE_PROVISIONING_APP,
-      STEP_IDS.CREATE_SAML_APP,
-    ];
+    // Get all checkable steps (those with a check function)
+    const checkableSteps = allStepDefinitions
+      .filter((step) => step.check !== undefined)
+      .map((step) => step.id as StepId);
 
-    for (const stepId of autoCheckSteps) {
+    for (const stepId of checkableSteps) {
       const status = stepsStatus[stepId];
 
-      if (status?.status === "completed") {
+      // Skip if already checking or in progress
+      if (status?.status === "in_progress") {
         continue;
       }
 
@@ -46,10 +41,7 @@ export function useAutoCheck(
     }
   }, [appConfig.domain, appConfig.tenantId, stepsStatus, executeCheck]);
 
-  useEffect(() => {
-    hasChecked.current = false;
-  }, [appConfig.domain]);
-
+  // Run checks whenever domain/tenantId changes or on mount
   useEffect(() => {
     if (appConfig.domain && appConfig.tenantId) {
       const timer = setTimeout(runChecks, 1000);


### PR DESCRIPTION
## Summary
- rework auto-check hook to run checks for all steps with a `check` handler whenever config is set
- filter persisted progress to exclude checkable steps and add migration helper
- add refresh button on dashboard to manually re-check step status

## Testing
- `pnpm test:build` *(fails: Creating an optimized production build ...)*
- `pnpm test:runtime` *(failed: no output)*

------
https://chatgpt.com/codex/tasks/task_e_6840f6d15118832294a1f655804f59ea