### PR TITLE
Fix domain step dependencies and UI output display

### DIFF
--- a/components/step-card.tsx
+++ b/components/step-card.tsx
@@ -417,7 +417,7 @@ export function StepCard({
                     </div>
                   </div>
                 )}
-                {producedOutputs.length > 0 && (
+                {isCompleted && producedOutputs.length > 0 && (
                   <div>
                     <h4 className="font-medium text-sm mb-1 text-foreground/90">
                       Outputs

--- a/lib/steps/google/create-automation-ou/execute.ts
+++ b/lib/steps/google/create-automation-ou/execute.ts
@@ -17,16 +17,17 @@ export async function executeCreateAutomationOu(
 ): Promise<StepExecutionResult> {
   try {
     const token = await getGoogleToken();
-    const validation = validateRequiredOutputs(context, []);
+    const validation = validateRequiredOutputs(
+      context,
+      [OUTPUT_KEYS.GWS_CUSTOMER_ID],
+      STEP_IDS.VERIFY_DOMAIN,
+    );
     if (!validation.valid) {
       return { success: false, error: validation.error };
     }
     const ouName = "Automation";
     const parentPath = "/";
-    const customerId = (context.outputs[STEP_IDS.VERIFY_DOMAIN] as { customerId?: string })?.customerId;
-    if (!customerId) {
-      return { success: false, error: { message: "Customer ID not found" } };
-    }
+    const customerId = context.outputs[OUTPUT_KEYS.GWS_CUSTOMER_ID] as string;
 
     const result = await google.createOrgUnit(token, ouName, parentPath, customerId);
 

--- a/lib/steps/google/create-automation-ou/index.ts
+++ b/lib/steps/google/create-automation-ou/index.ts
@@ -34,7 +34,7 @@ export const g1CreateAutomationOu: StepDefinition = {
 
   inputs: G1_INPUTS,
   outputs: G1_OUTPUTS,
-  requires: [],
+  requires: [STEP_IDS.VERIFY_DOMAIN],
   nextStep: {
     id: STEP_IDS.CREATE_PROVISIONING_USER,
     description: "Create a dedicated provisioning user in the Automation OU",

--- a/lib/steps/google/grant-super-admin/execute.ts
+++ b/lib/steps/google/grant-super-admin/execute.ts
@@ -16,12 +16,15 @@ export async function executeGrantSuperAdmin(
 ): Promise<StepExecutionResult> {
   try {
     const token = await getGoogleToken();
-    const validation = validateRequiredOutputs(context, [OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL]);
+    const validation = validateRequiredOutputs(
+      context,
+      [OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL, OUTPUT_KEYS.GWS_CUSTOMER_ID],
+    );
     if (!validation.valid) {
       return { success: false, error: validation.error };
     }
     const email = context.outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL] as string;
-    const customerId = (context.outputs[STEP_IDS.VERIFY_DOMAIN] as { customerId?: string })?.customerId;
+    const customerId = context.outputs[OUTPUT_KEYS.GWS_CUSTOMER_ID] as string;
     if (!email) {
       return {
         success: false,

--- a/lib/steps/google/grant-super-admin/index.ts
+++ b/lib/steps/google/grant-super-admin/index.ts
@@ -40,7 +40,7 @@ export const g3GrantSuperAdmin: StepDefinition = {
 
   inputs: G3_INPUTS,
   outputs: G3_OUTPUTS,
-  requires: [STEP_IDS.CREATE_PROVISIONING_USER],
+  requires: [STEP_IDS.CREATE_PROVISIONING_USER, STEP_IDS.VERIFY_DOMAIN],
   nextStep: { id: STEP_IDS.VERIFY_DOMAIN, description: "Verify your domain for federation" },
 
   actions: ["POST /admin/directory/v1/customer/{customerId}/roleassignments"],

--- a/lib/steps/google/index.ts
+++ b/lib/steps/google/index.ts
@@ -12,10 +12,10 @@ import { g7AssignSamlProfile } from "./assign-saml-profile";
 import { g8ExcludeAutomationOu } from "./exclude-automation-ou";
 
 export const googleSteps: StepDefinition[] = [
+  g4VerifyDomain,
   g1CreateAutomationOu,
   g2CreateProvisioningUser,
   g3GrantSuperAdmin,
-  g4VerifyDomain,
   g5InitiateSamlProfile,
   g6UpdateSamlProfile,
   g7AssignSamlProfile,

--- a/lib/steps/google/verify-domain/execute.ts
+++ b/lib/steps/google/verify-domain/execute.ts
@@ -1,6 +1,7 @@
 "use server";
 import * as google from "@/lib/api/google";
 import type { StepContext, StepExecutionResult } from "@/lib/types";
+import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
 import { getGoogleToken } from "../utils/auth";
 import { handleExecutionError } from "../../utils/error-handling";
@@ -26,14 +27,14 @@ export async function executeVerifyDomain(
         success: true,
         message: `Domain '${context.domain}' was already added/exists in Google Workspace.`,
         resourceUrl: portalUrls.google.domains.manage(context.domain),
-        outputs: { customerId: user.customerId },
+        outputs: { [OUTPUT_KEYS.GWS_CUSTOMER_ID]: user.customerId },
       };
     }
     return {
       success: true,
       message: `Domain '${context.domain}' added. Please ensure it is verified in your Google Workspace Admin console for SAML SSO.`,
       resourceUrl: portalUrls.google.domains.manage(context.domain),
-      outputs: { customerId: user.customerId },
+      outputs: { [OUTPUT_KEYS.GWS_CUSTOMER_ID]: user.customerId },
     };
   } catch (e) {
     return handleExecutionError(e, STEP_IDS.VERIFY_DOMAIN);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -167,12 +167,20 @@ export const OUTPUT_KEYS = {
   // Google - G-1: Create 'Automation' Organizational Unit
   GOOGLE_OU_PATH: "googleOuPath",
   GOOGLE_OU_ID: "googleOuId",
+  AUTOMATION_OU_PATH: "googleOuPath",
+  AUTOMATION_OU_ID: "googleOuId",
   // Google - G-2: Create Provisioning User
   GOOGLE_USER_EMAIL: "googleUserEmail",
   GOOGLE_USER_ID: "googleUserId",
   GOOGLE_USER_PASSWORD: "googleUserPassword",
+  SERVICE_ACCOUNT_EMAIL: "googleUserEmail",
+  SERVICE_ACCOUNT_ID: "googleUserId",
+  SERVICE_ACCOUNT_PASSWORD: "googleUserPassword",
   // Google - G-3: Grant Admin Privileges to Provisioning User
   GOOGLE_SUPERADMIN_ROLE_ID: "googleSuperAdminRoleId",
+  SUPER_ADMIN_ROLE_ID: "googleSuperAdminRoleId",
+  // Google - G-4: Verify Domain
+  GWS_CUSTOMER_ID: "g4GwsCustomerId",
   // Google - G-5: Initiate Google SAML Profile
   GOOGLE_SAML_PROFILE_NAME: "googleSamlProfileName",
   GOOGLE_SAML_PROFILE_FULL_NAME: "googleSamlProfileFullName",
@@ -183,20 +191,36 @@ export const OUTPUT_KEYS = {
   MS_APP_ID: "msAppId",
   MS_APP_OBJECT_ID: "msAppObjectId",
   MS_SP_OBJECT_ID: "msSpObjectId",
+  PROVISIONING_APP_ID: "msAppId",
+  PROVISIONING_APP_OBJECT_ID: "msAppObjectId",
+  PROVISIONING_SP_OBJECT_ID: "msSpObjectId",
   // Microsoft - M-3: Authorize Enterprise App
   MS_JOB_ID: "msJobId",
+  PROVISIONING_JOB_ID: "msJobId",
   // Microsoft - M-6: Create SAML SSO App
   MS_SAML_APP_ID: "msSamlAppId",
   MS_SAML_APP_OBJECT_ID: "msSamlAppObjectId",
   MS_SAML_SP_OBJECT_ID: "msSamlSpObjectId",
+  SAML_SSO_APP_ID: "msSamlAppId",
+  SAML_SSO_APP_OBJECT_ID: "msSamlAppObjectId",
+  SAML_SSO_SP_OBJECT_ID: "msSamlSpObjectId",
   // Microsoft - M-8: Retrieve IdP Metadata
   MS_IDP_CERT_BASE64: "msIdpCertBase64",
   MS_IDP_SSO_URL: "msIdpSsoUrl",
   MS_IDP_ENTITY_ID: "msIdpEntityId",
+  IDP_CERTIFICATE_BASE64: "msIdpCertBase64",
+  IDP_SSO_URL: "msIdpSsoUrl",
+  IDP_ENTITY_ID: "msIdpEntityId",
   // Flags for configuration steps
   MS_APP_PROPS_CONFIGURED: "msAppPropsConfigured",
   MS_CREDS_CONFIGURED: "msCredsConfigured",
   MS_MAPPINGS_CONFIGURED: "msMappingsConfigured",
   MS_SAML_APP_SETTINGS_CONFIGURED: "msSamlAppSettingsConfigured",
   MS_SSO_TESTED: "msSsoTested",
+  FLAG_M2_PROV_APP_PROPS_CONFIGURED: "msAppPropsConfigured",
+  FLAG_M3_PROV_CREDS_CONFIGURED: "msCredsConfigured",
+  FLAG_M4_PROV_MAPPINGS_CONFIGURED: "msMappingsConfigured",
+  FLAG_M7_SAML_APP_SETTINGS_CONFIGURED: "msSamlAppSettingsConfigured",
+  FLAG_M10_SSO_TESTED: "msSsoTested",
+  GOOGLE_SAML_ACS_URL: "googleSamlAcsUrl",
 };


### PR DESCRIPTION
## Summary
- standardize output keys and add missing aliases
- produce customer ID using the new output key
- require Verify Domain step in related Google steps
- start Google steps with Verify Domain
- hide outputs on incomplete steps
- adjust API logger for build compatibility

## Testing
- `pnpm test:build`
- `pnpm test:runtime`


------
https://chatgpt.com/codex/tasks/task_e_68410e98d48083229a402b2ad4ccf115