### PR TITLE
Remove toast notifications and improve API logging

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -9,7 +9,6 @@ import {
 import { useSession } from "next-auth/react";
 import { useRouter, useSearchParams } from "next/navigation";
 import React, { Suspense, useEffect, useState, useTransition } from "react";
-import { toast } from "sonner";
 
 import { lookupTenantId } from "@/app/actions/auth-actions";
 import { Button } from "@/components/ui/button";
@@ -73,10 +72,7 @@ function LoginPage() {
         errorMessage =
           "Your previous session was invalid. Please sign in again to both services.";
       }
-      toast.error(errorMessage, {
-        id: `login-error-${error}`,
-        duration: 10000,
-      });
+      console.error(errorMessage);
     }
   }, [searchParams]);
 
@@ -87,15 +83,11 @@ function LoginPage() {
 
     if (authAttempt && !error && sessionStatus === "authenticated") {
       if (authAttempt === "google" && !session?.hasGoogleAuth) {
-        toast.error("Google authentication failed. Please try again.", {
-          id: "google-auth-failed",
-          duration: 10000,
-        });
+        console.error("Google authentication failed. Please try again.");
       } else if (authAttempt === "microsoft" && !session?.hasMicrosoftAuth) {
-        toast.error("Microsoft authentication failed. Please try again.", {
-          id: "microsoft-auth-failed",
-          duration: 10000,
-        });
+        console.error(
+          "Microsoft authentication failed. Please try again.",
+        );
       }
     }
   }, [searchParams, session, sessionStatus]);
@@ -113,7 +105,7 @@ function LoginPage() {
 
   const onLookupTenant = async () => {
     if (!domain) {
-      toast.error("Please enter a domain first to lookup Tenant ID.");
+      console.error("Please enter a domain first to lookup Tenant ID.");
       return;
     }
     setIsLookingUpTenant(true);
@@ -123,17 +115,17 @@ function LoginPage() {
       setTenantId(result.tenantId);
       setIsTenantDiscovered(true);
       setLookupMessage(`Tenant ID found: ${result.tenantId}`);
-      toast.success("Tenant ID discovered!");
+      console.log("Tenant ID discovered!");
     } else {
       setLookupMessage(result.message || "Could not auto-discover Tenant ID.");
-      toast.error(result.message || "Tenant ID lookup failed.");
+      console.error(result.message || "Tenant ID lookup failed.");
     }
     setIsLookingUpTenant(false);
   };
 
   const onGoogleSignIn = () => {
     if (!domain) {
-      toast.error("Please enter your domain first");
+      console.error("Please enter your domain first");
       return;
     }
     startGoogleLoginTransition(async () => {
@@ -148,10 +140,7 @@ function LoginPage() {
       tenantId || process.env.NEXT_PUBLIC_MICROSOFT_TENANT_ID;
     // Domain is optional for MS login but used as hint when provided
     if (!effectiveTenantId && !process.env.MICROSOFT_TENANT_ID) {
-      toast.info(
-        "No Tenant ID found. Using default Microsoft sign-in.",
-        { duration: 7000 },
-      );
+      console.log("No Tenant ID found. Using default Microsoft sign-in.");
     }
     startMicrosoftLoginTransition(async () => {
       const formData = new FormData();

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,3 @@
-import { Toaster } from "@/components/ui/sonner";
 import type { Metadata } from "next";
 
 import { DebugPanel } from "@/components/debug-panel";
@@ -25,7 +24,6 @@ export default function RootLayout({
           <ModalManager />
           <DebugPanelNub />
           <DebugPanel />
-          <Toaster richColors />
         </Providers>
       </body>
     </html>

--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -14,7 +14,6 @@ import { useStepExecution } from "@/hooks/use-step-execution";
 import { useRouter } from "next/navigation";
 import React, { useCallback, useEffect, useMemo } from "react";
 import { useStore } from "react-redux";
-import { toast } from "sonner";
 
 import { useAppDispatch, useAppSelector } from "@/hooks/use-redux";
 import { setError } from "@/lib/redux/slices/errors";
@@ -118,9 +117,7 @@ export function AutomationDashboard({
         dispatch(initializeSteps(persisted.steps));
         // Merge outputs saved for this domain.
         dispatch(addOutputs(persisted.outputs || {}));
-        toast.info("Previous progress restored", {
-          duration: 2000,
-        });
+        console.log("Previous progress restored");
       } else {
         const initialStepStatuses: Record<string, { status: "pending" }> = {};
         allStepDefinitions.forEach((def) => {
@@ -311,14 +308,9 @@ export function AutomationDashboard({
 
   const runAllPending = useCallback(async () => {
     if (!canRunAutomation) {
-      // toast.error(
-      //   "Complete setup to run automation",
-      // );
       return;
     }
-    toast.info("Running automation...", {
-      duration: 5000,
-    });
+    console.log("Running automation...");
     let anyStepFailed = false;
     for (const step of allStepDefinitions) {
       const currentStepState = store.getState().setupSteps.steps[step.id];
@@ -330,19 +322,13 @@ export function AutomationDashboard({
       ) {
         await handleExecute(step.id as StepId);
         if (store.getState().setupSteps.steps[step.id]?.status === "failed") {
-          // toast.error("Automation paused", {
-          //   description: `Check the error in ${step.title}`,
-          //   duration: 10000,
-          // });
           anyStepFailed = true;
           break;
         }
       }
     }
     if (!anyStepFailed) {
-      toast.success("All steps completed", {
-        duration: 5000,
-      });
+      console.log("All steps completed");
     }
   }, [handleExecute, store, canRunAutomation]);
 
@@ -358,11 +344,11 @@ export function AutomationDashboard({
         return;
       }
       dispatch(clearAllCheckTimestamps());
-      toast.info("Refreshing step status...", { duration: 2000 });
+      console.log("Refreshing step status...");
 
       await manualRefresh();
 
-      toast.success("Status refreshed", { duration: 2000 });
+      console.log("Status refreshed");
     }, [canRunAutomation, manualRefresh, dispatch]);
 
     return (

--- a/components/debug-panel.tsx
+++ b/components/debug-panel.tsx
@@ -16,7 +16,6 @@ import {
 } from "@/lib/redux/slices/debug-panel";
 import { cn, isApiDebugEnabled } from "@/lib/utils";
 import { Bug, Trash2, X } from "lucide-react";
-import { toast } from "sonner";
 
 export function DebugPanel() {
   const dispatch = useAppDispatch();
@@ -40,12 +39,12 @@ export function DebugPanel() {
 
   const handleClearLogs = () => {
     dispatch(clearLogs());
-    toast.success("Logs cleared");
+    console.log("Logs cleared");
   };
 
   const handleCopyLog = (log: ApiLogEntry) => {
     navigator.clipboard.writeText(JSON.stringify(log, null, 2));
-    toast.success("Log copied to clipboard");
+    console.log("Log copied to clipboard");
   };
 
   return (

--- a/hooks/use-auto-check.ts
+++ b/hooks/use-auto-check.ts
@@ -46,12 +46,18 @@ export function useAutoCheck(
           status?.status === "pending";
 
         if (shouldCheck && !recentlyChecked) {
+          console.log(`[AutoCheck] Checking step ${stepId}`);
           const checkResult = await executeCheck(stepId);
+
           if (checkResult && 'apiLogs' in checkResult && checkResult.apiLogs) {
+            console.log(
+              `[AutoCheck] Adding ${checkResult.apiLogs.length} API logs for step ${stepId}`,
+            );
             checkResult.apiLogs.forEach((log) => {
               store.dispatch(addApiLog(log));
             });
           }
+
           checkedSteps.current.add(stepId);
           await new Promise((r) => setTimeout(r, 300));
         }
@@ -69,7 +75,6 @@ export function useAutoCheck(
     if (appConfig.domain && appConfig.tenantId) {
       debouncedRunChecks.current();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [appConfig.domain, appConfig.tenantId]);
 
   const manualRefresh = useCallback(async () => {

--- a/hooks/use-step-execution.ts
+++ b/hooks/use-step-execution.ts
@@ -6,7 +6,6 @@ import { executeStepAction } from '@/app/actions/step-actions';
 import type { StepId } from '@/lib/steps/step-refs';
 import { ErrorManager } from '@/lib/error-handling/error-manager';
 import { allStepDefinitions } from '@/lib/steps';
-import { toast } from 'sonner';
 import { addApiLog } from '@/lib/redux/slices/debug-panel';
 
 export function useStepExecution() {
@@ -30,8 +29,6 @@ export function useStepExecution() {
           message: undefined,
         })
       );
-
-      const toastId = toast.loading(`Executing: ${definition.title}...`);
 
       try {
         const context = {
@@ -66,7 +63,7 @@ export function useStepExecution() {
               lastCheckedAt: new Date().toISOString(),
             })
           );
-          toast.success(`${definition.title}: Success!`, { id: toastId });
+          console.log(`[useStepExecution] ${definition.title} succeeded`);
         } else {
           dispatch(
             updateStep({
@@ -85,11 +82,13 @@ export function useStepExecution() {
               { stepId, stepTitle: definition.title }
             );
           } else {
-            toast.error(`${definition.title}: ${result.error?.message}`, { id: toastId });
+            console.error(
+              `[useStepExecution] ${definition.title} failed:`,
+              result.error?.message,
+            );
           }
         }
       } catch (error) {
-        toast.dismiss(toastId);
       dispatch(
         updateStep({
           id: stepId,

--- a/lib/api/async-local-storage-polyfill.ts
+++ b/lib/api/async-local-storage-polyfill.ts
@@ -1,0 +1,18 @@
+// Polyfill for AsyncLocalStorage when not available
+export class AsyncLocalStorage<T> {
+  private store: T | undefined;
+
+  run<R>(store: T, fn: () => R): R {
+    const previousStore = this.store;
+    this.store = store;
+    try {
+      return fn();
+    } finally {
+      this.store = previousStore;
+    }
+  }
+
+  getStore(): T | undefined {
+    return this.store;
+  }
+}

--- a/lib/api/utils.ts
+++ b/lib/api/utils.ts
@@ -1,6 +1,4 @@
 import { ApiLogger } from "./api-logger";
-import { store } from "@/lib/redux/store";
-import { addApiLog } from "@/lib/redux/slices/debug-panel";
 
 /**
  * Error thrown when an API call fails.
@@ -110,19 +108,9 @@ export async function handleApiResponse<T>(
     };
     const message =
       errorBody.error?.message ?? `Connection failed. Please try again.`;
-    const errorLogId = `error-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
-    store.dispatch(
-      addApiLog({
-        id: errorLogId,
-        timestamp: new Date().toISOString(),
-        method: "ERROR",
-        url: "API Error",
-        error: `${res.status}: ${message}`,
-        responseStatus: res.status,
-        responseBody: errorBody,
-        provider: "other",
-      }),
-    );
+
+    // API errors will be logged by ApiLogger which is already tracking this response
+
     throw new APIError(message, res.status, errorBody.error?.code);
   }
   if (res.status === 204) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -165,38 +165,43 @@ export type ManagedStep = StepDefinition & StepStatusInfo;
  */
 export const OUTPUT_KEYS = {
   // Google - G-1: Create 'Automation' Organizational Unit
-  GOOGLE_OU_PATH: "googleOuPath",
-  GOOGLE_OU_ID: "googleOuId",
+  AUTOMATION_OU_PATH: "g1AutomationOuPath",
+  AUTOMATION_OU_ID: "g1AutomationOuId",
   // Google - G-2: Create Provisioning User
-  GOOGLE_USER_EMAIL: "googleUserEmail",
-  GOOGLE_USER_ID: "googleUserId",
-  GOOGLE_USER_PASSWORD: "googleUserPassword",
+  SERVICE_ACCOUNT_EMAIL: "g2ServiceAccountEmail",
+  SERVICE_ACCOUNT_ID: "g2ServiceAccountId",
+  SERVICE_ACCOUNT_PASSWORD: "g2ServiceAccountPassword",
   // Google - G-3: Grant Admin Privileges to Provisioning User
-  GOOGLE_SUPERADMIN_ROLE_ID: "googleSuperAdminRoleId",
+  SUPER_ADMIN_ROLE_ID: "g3SuperAdminRoleId",
   // Google - G-5: Initiate Google SAML Profile
-  GOOGLE_SAML_PROFILE_NAME: "googleSamlProfileName",
-  GOOGLE_SAML_PROFILE_FULL_NAME: "googleSamlProfileFullName",
+  GOOGLE_SAML_PROFILE_NAME: "g5GoogleSsoProfileName",
+  GOOGLE_SAML_PROFILE_FULL_NAME: "g5GoogleSsoProfileFullName",
   // Google SAML Service Provider config
-  GOOGLE_SAML_SP_ENTITY_ID: "googleSamlEntityId",
-  GOOGLE_SAML_SP_ACS_URL: "googleSamlAcsUrl",
-  // Microsoft - M-1: Create Enterprise App
-  MS_APP_ID: "msAppId",
-  MS_APP_OBJECT_ID: "msAppObjectId",
-  MS_SP_OBJECT_ID: "msSpObjectId",
-  // Microsoft - M-3: Authorize Enterprise App
-  MS_JOB_ID: "msJobId",
+  GOOGLE_SAML_SP_ENTITY_ID: "g5GoogleSamlSpEntityId",
+  GOOGLE_SAML_ACS_URL: "g5GoogleSamlAcsUrl",
+
+  // Microsoft - M-1: Create Provisioning App
+  PROVISIONING_APP_ID: "m1ProvisioningAppId",
+  PROVISIONING_APP_OBJECT_ID: "m1ProvisioningAppObjectId",
+  PROVISIONING_SP_OBJECT_ID: "m1ProvisioningSpObjectId",
+
+  // Microsoft - M-3: Authorize Provisioning Connection
+  PROVISIONING_JOB_ID: "m3ProvisioningJobId",
+
   // Microsoft - M-6: Create SAML SSO App
-  MS_SAML_APP_ID: "msSamlAppId",
-  MS_SAML_APP_OBJECT_ID: "msSamlAppObjectId",
-  MS_SAML_SP_OBJECT_ID: "msSamlSpObjectId",
+  SAML_SSO_APP_ID: "m6SamlSsoAppId",
+  SAML_SSO_APP_OBJECT_ID: "m6SamlSsoAppObjectId",
+  SAML_SSO_SP_OBJECT_ID: "m6SamlSsoSpObjectId",
+
   // Microsoft - M-8: Retrieve IdP Metadata
-  MS_IDP_CERT_BASE64: "msIdpCertBase64",
-  MS_IDP_SSO_URL: "msIdpSsoUrl",
-  MS_IDP_ENTITY_ID: "msIdpEntityId",
+  IDP_CERTIFICATE_BASE64: "m8IdpCertificateBase64",
+  IDP_SSO_URL: "m8IdpSsoUrl",
+  IDP_ENTITY_ID: "m8IdpEntityId",
+
   // Flags for configuration steps
-  MS_APP_PROPS_CONFIGURED: "msAppPropsConfigured",
-  MS_CREDS_CONFIGURED: "msCredsConfigured",
-  MS_MAPPINGS_CONFIGURED: "msMappingsConfigured",
-  MS_SAML_APP_SETTINGS_CONFIGURED: "msSamlAppSettingsConfigured",
-  MS_SSO_TESTED: "msSsoTested",
+  FLAG_M2_PROV_APP_PROPS_CONFIGURED: "flagM2ProvAppPropsConfigured",
+  FLAG_M3_PROV_CREDS_CONFIGURED: "flagM3ProvCredsConfigured",
+  FLAG_M4_PROV_MAPPINGS_CONFIGURED: "flagM4ProvMappingsConfigured",
+  FLAG_M7_SAML_APP_SETTINGS_CONFIGURED: "flagM7SamlAppSettingsConfigured",
+  FLAG_M10_SSO_TESTED: "flagM10SsoTested",
 };


### PR DESCRIPTION
## Summary
- refactor API logger to use AsyncLocalStorage for per-request context
- add AsyncLocalStorage polyfill for browser environments
- remove server Redux dispatch from `handleApiResponse`
- revise step action helpers to use new logger API
- drop toast notifications and toaster component
- clean up auto-check and step execution hooks
- replace toast usage in components with console logging
- restore output key constants for steps

## Testing
- `pnpm test:build`
- `pnpm test:runtime`


------
https://chatgpt.com/codex/tasks/task_e_68410950c9dc83228285810d9b2b50c6