### PR TITLE
Implement error boundary helper

### DIFF
--- a/lib/errors/boundary.ts
+++ b/lib/errors/boundary.ts
@@ -1,0 +1,31 @@
+import { ErrorManager, ManagedError } from "@/lib/error-handling/error-manager";
+
+export interface ErrorContext {
+  stepId?: string;
+  stepTitle?: string;
+  action?: string;
+}
+
+export interface Result<T> {
+  success: boolean;
+  data?: T;
+  error?: ManagedError;
+}
+
+export async function withErrorBoundary<T>(
+  operation: () => Promise<T>,
+  context: ErrorContext = {},
+): Promise<Result<T>> {
+  try {
+    const data = await operation();
+    return { success: true, data };
+  } catch (error) {
+    ErrorManager.dispatch(error, { stepId: context.stepId, stepTitle: context.stepTitle });
+    const managed = ErrorManager.handle(error, {
+      stepId: context.stepId,
+      stepTitle: context.stepTitle,
+    });
+    return { success: false, error: managed };
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `lib/errors/boundary.ts` providing `withErrorBoundary` for unified async error handling

## Testing
- `pnpm lint --fix`
- `pnpm type-check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684144d2b42483229e92695597982ecb