### PR TITLE
Implement typed output helper

### DIFF
--- a/lib/steps/google/assign-saml-profile/check.ts
+++ b/lib/steps/google/assign-saml-profile/check.ts
@@ -4,13 +4,15 @@ import { getGoogleToken } from "../../utils/auth";
 import * as google from "@/lib/api/google";
 import { portalUrls } from "@/lib/api/url-builder";
 import { handleCheckError } from "../../utils/error-handling";
+import { getRequiredOutput } from "../../utils/get-output";
 
 export const checkAssignSamlProfile = createStepCheck({
   requiredOutputs: [OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME],
   checkLogic: async (context) => {
-    const profileName = context.outputs[
-      OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME
-    ] as string;
+    const profileName = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME,
+    );
     try {
       const token = await getGoogleToken();
       let profile: google.InboundSamlSsoProfile | null = null;

--- a/lib/steps/google/assign-saml-profile/execute.ts
+++ b/lib/steps/google/assign-saml-profile/execute.ts
@@ -5,15 +5,17 @@ import { portalUrls } from "@/lib/api/url-builder";
 import { getGoogleToken } from "../../utils/auth";
 import { STEP_IDS } from "@/lib/steps/step-refs";
 import { withExecutionHandling } from "../../utils/execute-wrapper";
+import { getRequiredOutput } from "../../utils/get-output";
 
 export const executeAssignSamlProfile = withExecutionHandling({
   stepId: STEP_IDS.ASSIGN_SAML_PROFILE,
   requiredOutputs: [OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME],
   executeLogic: async (context: StepContext): Promise<StepExecutionResult> => {
     const token = await getGoogleToken();
-    const profileFullName = context.outputs[
-      OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME
-    ] as string;
+    const profileFullName = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME,
+    );
 
     await google.assignSamlToOrgUnits(
       token,

--- a/lib/steps/google/create-automation-ou/execute.ts
+++ b/lib/steps/google/create-automation-ou/execute.ts
@@ -7,6 +7,7 @@ import { getGoogleToken } from "../../utils/auth";
 import { STEP_IDS } from "@/lib/steps/step-refs";
 import { withExecutionHandling } from "../../utils/execute-wrapper";
 import { validateRequiredOutputs } from "../../utils/validation";
+import { getRequiredOutput } from "../../utils/get-output";
 
 export const executeCreateAutomationOu = withExecutionHandling({
   stepId: STEP_IDS.CREATE_AUTOMATION_OU,
@@ -25,7 +26,7 @@ export const executeCreateAutomationOu = withExecutionHandling({
     const ouName = "Automation";
     const parentPath = "/";
     const customerId = (
-      context.outputs[STEP_IDS.VERIFY_DOMAIN] as { customerId?: string }
+      getRequiredOutput<{ customerId?: string }>(context, STEP_IDS.VERIFY_DOMAIN)
     )?.customerId;
     if (!customerId) {
       return {

--- a/lib/steps/google/create-provisioning-user/execute.ts
+++ b/lib/steps/google/create-provisioning-user/execute.ts
@@ -6,6 +6,7 @@ import { AlreadyExistsError } from "@/lib/api/errors";
 import { getGoogleToken } from "../../utils/auth";
 import { STEP_IDS } from "@/lib/steps/step-refs";
 import { withExecutionHandling } from "../../utils/execute-wrapper";
+import { getRequiredOutput } from "../../utils/get-output";
 
 export const executeCreateProvisioningUser = withExecutionHandling({
   stepId: STEP_IDS.CREATE_PROVISIONING_USER,
@@ -13,7 +14,10 @@ export const executeCreateProvisioningUser = withExecutionHandling({
   executeLogic: async (context: StepContext): Promise<StepExecutionResult> => {
     const token = await getGoogleToken();
     const domain = context.domain;
-    const ouPath = context.outputs[OUTPUT_KEYS.AUTOMATION_OU_PATH] as string;
+    const ouPath = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.AUTOMATION_OU_PATH,
+    );
 
     const email = `azuread-provisioning@${domain}`;
     const tempPassword = `P@${Date.now()}w0rd`;

--- a/lib/steps/google/exclude-automation-ou/check.ts
+++ b/lib/steps/google/exclude-automation-ou/check.ts
@@ -4,13 +4,15 @@ import { portalUrls } from "@/lib/api/url-builder";
 import { getGoogleToken } from "../../utils/auth";
 import { createStepCheck } from "../../utils/check-factory";
 import { handleCheckError } from "../../utils/error-handling";
+import { getRequiredOutput } from "../../utils/get-output";
 
 export const checkExcludeAutomationOu = createStepCheck({
   requiredOutputs: [OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME],
   checkLogic: async (context) => {
-    const profileName = context.outputs[
-      OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME
-    ] as string;
+    const profileName = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME,
+    );
     try {
       const token = await getGoogleToken();
       let profile: google.InboundSamlSsoProfile | null = null;

--- a/lib/steps/google/exclude-automation-ou/execute.ts
+++ b/lib/steps/google/exclude-automation-ou/execute.ts
@@ -5,15 +5,17 @@ import { portalUrls } from "@/lib/api/url-builder";
 import { getGoogleToken } from "../../utils/auth";
 import { STEP_IDS } from "@/lib/steps/step-refs";
 import { withExecutionHandling } from "../../utils/execute-wrapper";
+import { getRequiredOutput } from "../../utils/get-output";
 
 export const executeExcludeAutomationOu = withExecutionHandling({
   stepId: STEP_IDS.EXCLUDE_AUTOMATION_OU,
   requiredOutputs: [OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME],
   executeLogic: async (context: StepContext): Promise<StepExecutionResult> => {
     const token = await getGoogleToken();
-    const profileFullName = context.outputs[
-      OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME
-    ] as string;
+    const profileFullName = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME,
+    );
 
     await google.assignSamlToOrgUnits(
       token,

--- a/lib/steps/google/grant-super-admin/check.ts
+++ b/lib/steps/google/grant-super-admin/check.ts
@@ -3,11 +3,15 @@ import { createStepCheck } from "../../utils/check-factory";
 import * as google from "@/lib/api/google";
 import { getGoogleToken } from "../../utils/auth";
 import { handleCheckError } from "../../utils/error-handling";
+import { getRequiredOutput } from "../../utils/get-output";
 
 export const checkSuperAdmin = createStepCheck({
   requiredOutputs: [OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL],
   checkLogic: async (context) => {
-    const email = context.outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL] as string;
+    const email = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL,
+    );
     try {
       const token = await getGoogleToken();
       const user = await google.getUser(token, email, context.logger);

--- a/lib/steps/google/grant-super-admin/execute.ts
+++ b/lib/steps/google/grant-super-admin/execute.ts
@@ -6,6 +6,7 @@ import { getGoogleToken } from "../../utils/auth";
 import { STEP_IDS } from "@/lib/steps/step-refs";
 import { withExecutionHandling } from "../../utils/execute-wrapper";
 import { validateRequiredOutputs } from "../../utils/validation";
+import { getRequiredOutput } from "../../utils/get-output";
 
 export const executeGrantSuperAdmin = withExecutionHandling({
   stepId: STEP_IDS.GRANT_SUPER_ADMIN,
@@ -24,10 +25,14 @@ export const executeGrantSuperAdmin = withExecutionHandling({
     if (!validation.valid) {
       return { success: false, error: validation.error };
     }
-    const email = context.outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL] as string;
-    const customerId = context.outputs[
-      OUTPUT_KEYS.GOOGLE_CUSTOMER_ID
-    ] as string;
+    const email = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL,
+    );
+    const customerId = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.GOOGLE_CUSTOMER_ID,
+    );
     if (!email) {
       return {
         success: false,

--- a/lib/steps/google/update-saml-profile/check.ts
+++ b/lib/steps/google/update-saml-profile/check.ts
@@ -4,6 +4,7 @@ import * as google from "@/lib/api/google";
 import { portalUrls } from "@/lib/api/url-builder";
 import { getGoogleToken } from "../../utils/auth";
 import { handleCheckError } from "../../utils/error-handling";
+import { getRequiredOutput } from "../../utils/get-output";
 
 export const checkSamlProfileUpdate = createStepCheck({
   requiredOutputs: [
@@ -11,12 +12,14 @@ export const checkSamlProfileUpdate = createStepCheck({
     OUTPUT_KEYS.IDP_ENTITY_ID,
   ],
   checkLogic: async (context) => {
-    const profileName = context.outputs[
-      OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME
-    ] as string;
-    const expectedIdpEntityId = context.outputs[
-      OUTPUT_KEYS.IDP_ENTITY_ID
-    ] as string;
+    const profileName = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME,
+    );
+    const expectedIdpEntityId = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.IDP_ENTITY_ID,
+    );
     try {
       const token = await getGoogleToken();
       let profile: google.InboundSamlSsoProfile | null = null;

--- a/lib/steps/google/update-saml-profile/execute.ts
+++ b/lib/steps/google/update-saml-profile/execute.ts
@@ -5,6 +5,7 @@ import { portalUrls } from "@/lib/api/url-builder";
 import { getGoogleToken } from "../../utils/auth";
 import { STEP_IDS } from "@/lib/steps/step-refs";
 import { withExecutionHandling } from "../../utils/execute-wrapper";
+import { getRequiredOutput } from "../../utils/get-output";
 
 export const executeUpdateSamlProfile = withExecutionHandling({
   stepId: STEP_IDS.UPDATE_SAML_PROFILE,
@@ -16,12 +17,16 @@ export const executeUpdateSamlProfile = withExecutionHandling({
   ],
   executeLogic: async (context: StepContext): Promise<StepExecutionResult> => {
     const token = await getGoogleToken();
-    const profileName = context.outputs[
-      OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME
-    ] as string;
-    const idpSsoUrl = context.outputs[OUTPUT_KEYS.IDP_SSO_URL] as string;
-    const idpEntityId = context.outputs[OUTPUT_KEYS.IDP_ENTITY_ID] as string;
-    const cert = context.outputs[OUTPUT_KEYS.IDP_CERTIFICATE_BASE64] as string;
+    const profileName = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME,
+    );
+    const idpSsoUrl = getRequiredOutput<string>(context, OUTPUT_KEYS.IDP_SSO_URL);
+    const idpEntityId = getRequiredOutput<string>(context, OUTPUT_KEYS.IDP_ENTITY_ID);
+    const cert = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.IDP_CERTIFICATE_BASE64,
+    );
 
     await google.updateSamlProfile(
       token,

--- a/lib/steps/microsoft/assign-users-sso/check.ts
+++ b/lib/steps/microsoft/assign-users-sso/check.ts
@@ -1,11 +1,15 @@
 import { OUTPUT_KEYS } from "@/lib/types";
 import { createStepCheck } from "../../utils/check-factory";
 import { checkMicrosoftAppAssignments } from "../utils/common-checks";
+import { getRequiredOutput } from "../../utils/get-output";
 
 export const checkAssignUsers = createStepCheck({
   requiredOutputs: [OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID],
   checkLogic: async (context) => {
-    const spId = context.outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID] as string;
+    const spId = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID,
+    );
     const result = await checkMicrosoftAppAssignments(spId);
     return result;
   },

--- a/lib/steps/microsoft/assign-users-sso/execute.ts
+++ b/lib/steps/microsoft/assign-users-sso/execute.ts
@@ -3,6 +3,7 @@ import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
 import { STEP_IDS } from "@/lib/steps/step-refs";
 import { withExecutionHandling } from "../../utils/execute-wrapper";
+import { getRequiredOutput } from "../../utils/get-output";
 
 export const executeAssignUsers = withExecutionHandling({
   stepId: STEP_IDS.ASSIGN_USERS_SSO,
@@ -11,8 +12,14 @@ export const executeAssignUsers = withExecutionHandling({
     OUTPUT_KEYS.SAML_SSO_APP_ID,
   ],
   executeLogic: async (context: StepContext): Promise<StepExecutionResult> => {
-    const spId = context.outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID] as string;
-    const appId = context.outputs[OUTPUT_KEYS.SAML_SSO_APP_ID] as string;
+    const spId = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID,
+    );
+    const appId = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.SAML_SSO_APP_ID,
+    );
     return {
       success: true,
       message: "Assign users or groups to the SAML app in Azure Portal.",

--- a/lib/steps/microsoft/authorize-provisioning/check.ts
+++ b/lib/steps/microsoft/authorize-provisioning/check.ts
@@ -1,13 +1,15 @@
 import { OUTPUT_KEYS } from "@/lib/types";
 import { createStepCheck } from "../../utils/check-factory";
 import { checkMicrosoftProvisioningJobDetails } from "../utils/common-checks";
+import { getRequiredOutput } from "../../utils/get-output";
 
 export const checkAuthorizeProvisioning = createStepCheck({
   requiredOutputs: [OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID],
   checkLogic: async (context) => {
-    const spId = context.outputs[
-      OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID
-    ] as string;
+    const spId = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID,
+    );
     const jobId = context.outputs[OUTPUT_KEYS.PROVISIONING_JOB_ID] as
       | string
       | undefined;

--- a/lib/steps/microsoft/authorize-provisioning/execute.ts
+++ b/lib/steps/microsoft/authorize-provisioning/execute.ts
@@ -3,6 +3,7 @@ import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
 import { STEP_IDS } from "@/lib/steps/step-refs";
 import { withExecutionHandling } from "../../utils/execute-wrapper";
+import { getRequiredOutput } from "../../utils/get-output";
 
 export const executeAuthorizeProvisioning = withExecutionHandling({
   stepId: STEP_IDS.AUTHORIZE_PROVISIONING,
@@ -11,10 +12,14 @@ export const executeAuthorizeProvisioning = withExecutionHandling({
     OUTPUT_KEYS.PROVISIONING_APP_ID,
   ],
   executeLogic: async (context: StepContext): Promise<StepExecutionResult> => {
-    const spId = context.outputs[
-      OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID
-    ] as string;
-    const appId = context.outputs[OUTPUT_KEYS.PROVISIONING_APP_ID] as string;
+    const spId = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID,
+    );
+    const appId = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.PROVISIONING_APP_ID,
+    );
     const resourceUrl = portalUrls.azure.enterpriseApp.provisioning(
       spId,
       appId,

--- a/lib/steps/microsoft/configure-attribute-mappings/check.ts
+++ b/lib/steps/microsoft/configure-attribute-mappings/check.ts
@@ -1,6 +1,7 @@
 import { OUTPUT_KEYS } from "@/lib/types";
 import { createStepCheck } from "../../utils/check-factory";
 import { checkMicrosoftAttributeMappingsApplied } from "../utils/common-checks";
+import { getRequiredOutput } from "../../utils/get-output";
 
 export const checkAttributeMappings = createStepCheck({
   requiredOutputs: [
@@ -8,10 +9,11 @@ export const checkAttributeMappings = createStepCheck({
     OUTPUT_KEYS.PROVISIONING_JOB_ID,
   ],
   checkLogic: async (context) => {
-    const spId = context.outputs[
-      OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID
-    ] as string;
-    const jobId = context.outputs[OUTPUT_KEYS.PROVISIONING_JOB_ID] as string;
+    const spId = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID,
+    );
+    const jobId = getRequiredOutput<string>(context, OUTPUT_KEYS.PROVISIONING_JOB_ID);
     const result = await checkMicrosoftAttributeMappingsApplied(spId, jobId);
     return result;
   },

--- a/lib/steps/microsoft/configure-attribute-mappings/execute.ts
+++ b/lib/steps/microsoft/configure-attribute-mappings/execute.ts
@@ -6,6 +6,7 @@ import { portalUrls } from "@/lib/api/url-builder";
 import { getTokens } from "../../utils/auth";
 import { STEP_IDS } from "@/lib/steps/step-refs";
 import { withExecutionHandling } from "../../utils/execute-wrapper";
+import { getRequiredOutput } from "../../utils/get-output";
 
 export const executeConfigureAttributeMappings = withExecutionHandling({
   stepId: STEP_IDS.CONFIGURE_ATTRIBUTE_MAPPINGS,
@@ -16,11 +17,12 @@ export const executeConfigureAttributeMappings = withExecutionHandling({
   ],
   executeLogic: async (context: StepContext): Promise<StepExecutionResult> => {
     const { microsoftToken } = await getTokens();
-    const spId = context.outputs[
-      OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID
-    ] as string;
-    const appId = context.outputs[OUTPUT_KEYS.PROVISIONING_APP_ID] as string;
-    const jobId = context.outputs[OUTPUT_KEYS.PROVISIONING_JOB_ID] as string;
+    const spId = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID,
+    );
+    const appId = getRequiredOutput<string>(context, OUTPUT_KEYS.PROVISIONING_APP_ID);
+    const jobId = getRequiredOutput<string>(context, OUTPUT_KEYS.PROVISIONING_JOB_ID);
 
     const schema: MicrosoftGraph.SynchronizationTemplate = {
       id: "GoogleApps",

--- a/lib/steps/microsoft/configure-saml-app/check.ts
+++ b/lib/steps/microsoft/configure-saml-app/check.ts
@@ -1,6 +1,7 @@
 import { OUTPUT_KEYS } from "@/lib/types";
 import { createStepCheck } from "../../utils/check-factory";
 import { checkMicrosoftSamlAppSettingsApplied } from "../utils/common-checks";
+import { getRequiredOutput } from "../../utils/get-output";
 
 export const checkConfigureSamlApp = createStepCheck({
   requiredOutputs: [
@@ -9,15 +10,18 @@ export const checkConfigureSamlApp = createStepCheck({
     OUTPUT_KEYS.GOOGLE_SAML_SP_ACS_URL,
   ],
   checkLogic: async (context) => {
-    const appObjectId = context.outputs[
-      OUTPUT_KEYS.SAML_SSO_APP_OBJECT_ID
-    ] as string;
-    const spEntityId = context.outputs[
-      OUTPUT_KEYS.GOOGLE_SAML_SP_ENTITY_ID
-    ] as string;
-    const acsUrl = context.outputs[
-      OUTPUT_KEYS.GOOGLE_SAML_SP_ACS_URL
-    ] as string;
+    const appObjectId = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.SAML_SSO_APP_OBJECT_ID,
+    );
+    const spEntityId = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.GOOGLE_SAML_SP_ENTITY_ID,
+    );
+    const acsUrl = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.GOOGLE_SAML_SP_ACS_URL,
+    );
     const result = await checkMicrosoftSamlAppSettingsApplied(
       appObjectId,
       spEntityId,

--- a/lib/steps/microsoft/configure-saml-app/execute.ts
+++ b/lib/steps/microsoft/configure-saml-app/execute.ts
@@ -5,6 +5,7 @@ import { portalUrls } from "@/lib/api/url-builder";
 import { getTokens } from "../../utils/auth";
 import { STEP_IDS } from "@/lib/steps/step-refs";
 import { withExecutionHandling } from "../../utils/execute-wrapper";
+import { getRequiredOutput } from "../../utils/get-output";
 
 export const executeConfigureSamlApp = withExecutionHandling({
   stepId: STEP_IDS.CONFIGURE_SAML_APP,
@@ -17,20 +18,24 @@ export const executeConfigureSamlApp = withExecutionHandling({
   ],
   executeLogic: async (context: StepContext): Promise<StepExecutionResult> => {
     const { microsoftToken } = await getTokens();
-    const appObjectId = context.outputs[
-      OUTPUT_KEYS.SAML_SSO_APP_OBJECT_ID
-    ] as string;
-    const spObjectId = context.outputs[
-      OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID
-    ] as string;
-    const appId = context.outputs[OUTPUT_KEYS.SAML_SSO_APP_ID] as string;
-    const googleSpEntityId = context.outputs[
-      OUTPUT_KEYS.GOOGLE_SAML_SP_ENTITY_ID
-    ] as string;
-    const googleAcsUrl = context.outputs[
-      OUTPUT_KEYS.GOOGLE_SAML_SP_ACS_URL
-    ] as string;
-    const primaryDomain = context.domain as string;
+    const appObjectId = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.SAML_SSO_APP_OBJECT_ID,
+    );
+    const spObjectId = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID,
+    );
+    const appId = getRequiredOutput<string>(context, OUTPUT_KEYS.SAML_SSO_APP_ID);
+    const googleSpEntityId = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.GOOGLE_SAML_SP_ENTITY_ID,
+    );
+    const googleAcsUrl = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.GOOGLE_SAML_SP_ACS_URL,
+    );
+    const primaryDomain = context.domain;
 
     const appPatchPayload: Partial<microsoft.Application> = {
       identifierUris: [googleSpEntityId, `https://${primaryDomain}`],

--- a/lib/steps/microsoft/create-provisioning-app/check.ts
+++ b/lib/steps/microsoft/create-provisioning-app/check.ts
@@ -1,11 +1,15 @@
 import { OUTPUT_KEYS } from "@/lib/types";
 import { createStepCheck } from "../../utils/check-factory";
 import { checkMicrosoftServicePrincipal } from "../utils/common-checks";
+import { getRequiredOutput } from "../../utils/get-output";
 
 export const checkProvisioningApp = createStepCheck({
   requiredOutputs: [OUTPUT_KEYS.PROVISIONING_APP_ID],
   checkLogic: async (context) => {
-    const appId = context.outputs[OUTPUT_KEYS.PROVISIONING_APP_ID] as string;
+    const appId = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.PROVISIONING_APP_ID,
+    );
     const result = await checkMicrosoftServicePrincipal(appId);
 
     if (result.completed && result.outputs) {

--- a/lib/steps/microsoft/create-saml-app/check.ts
+++ b/lib/steps/microsoft/create-saml-app/check.ts
@@ -1,11 +1,12 @@
 import { OUTPUT_KEYS } from "@/lib/types";
 import { createStepCheck } from "../../utils/check-factory";
 import { checkMicrosoftServicePrincipal } from "../utils/common-checks";
+import { getRequiredOutput } from "../../utils/get-output";
 
 export const checkCreateSamlApp = createStepCheck({
   requiredOutputs: [OUTPUT_KEYS.SAML_SSO_APP_ID],
   checkLogic: async (context) => {
-    const appId = context.outputs[OUTPUT_KEYS.SAML_SSO_APP_ID] as string;
+    const appId = getRequiredOutput<string>(context, OUTPUT_KEYS.SAML_SSO_APP_ID);
     const result = await checkMicrosoftServicePrincipal(appId);
     if (result.completed && result.outputs) {
       return {

--- a/lib/steps/microsoft/enable-provisioning-sp/check.ts
+++ b/lib/steps/microsoft/enable-provisioning-sp/check.ts
@@ -1,13 +1,15 @@
 import { OUTPUT_KEYS } from "@/lib/types";
 import { createStepCheck } from "../../utils/check-factory";
 import { checkMicrosoftServicePrincipalEnabled } from "../utils/common-checks";
+import { getRequiredOutput } from "../../utils/get-output";
 
 export const checkEnableProvisioningSp = createStepCheck({
   requiredOutputs: [OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID],
   checkLogic: async (context) => {
-    const spId = context.outputs[
-      OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID
-    ] as string;
+    const spId = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID,
+    );
     const result = await checkMicrosoftServicePrincipalEnabled(spId);
     return result;
   },

--- a/lib/steps/microsoft/enable-provisioning-sp/execute.ts
+++ b/lib/steps/microsoft/enable-provisioning-sp/execute.ts
@@ -5,6 +5,7 @@ import { portalUrls } from "@/lib/api/url-builder";
 import { getTokens } from "../../utils/auth";
 import { STEP_IDS } from "@/lib/steps/step-refs";
 import { withExecutionHandling } from "../../utils/execute-wrapper";
+import { getRequiredOutput } from "../../utils/get-output";
 
 export const executeEnableProvisioningSp = withExecutionHandling({
   stepId: STEP_IDS.ENABLE_PROVISIONING_SP,
@@ -14,10 +15,11 @@ export const executeEnableProvisioningSp = withExecutionHandling({
   ],
   executeLogic: async (context: StepContext): Promise<StepExecutionResult> => {
     const { microsoftToken } = await getTokens();
-    const spId = context.outputs[
-      OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID
-    ] as string;
-    const appId = context.outputs[OUTPUT_KEYS.PROVISIONING_APP_ID] as string;
+    const spId = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID,
+    );
+    const appId = getRequiredOutput<string>(context, OUTPUT_KEYS.PROVISIONING_APP_ID);
 
     await microsoft.patchServicePrincipal(microsoftToken, spId, {
       accountEnabled: true,

--- a/lib/steps/microsoft/retrieve-idp-metadata/execute.ts
+++ b/lib/steps/microsoft/retrieve-idp-metadata/execute.ts
@@ -5,6 +5,7 @@ import { portalUrls } from "@/lib/api/url-builder";
 import { getTokens } from "../../utils/auth";
 import { STEP_IDS } from "@/lib/steps/step-refs";
 import { withExecutionHandling } from "../../utils/execute-wrapper";
+import { getRequiredOutput } from "../../utils/get-output";
 
 export const executeRetrieveIdpMetadata = withExecutionHandling({
   stepId: STEP_IDS.RETRIEVE_IDP_METADATA,
@@ -14,8 +15,8 @@ export const executeRetrieveIdpMetadata = withExecutionHandling({
   ],
   executeLogic: async (context: StepContext): Promise<StepExecutionResult> => {
     const { tenantId } = await getTokens();
-    const appId = context.outputs[OUTPUT_KEYS.SAML_SSO_APP_ID] as string;
-    const spId = context.outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID] as string;
+    const appId = getRequiredOutput<string>(context, OUTPUT_KEYS.SAML_SSO_APP_ID);
+    const spId = getRequiredOutput<string>(context, OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID);
     const { certificate, ssoUrl, entityId } = await microsoft.getSamlMetadata(
       tenantId,
       appId,

--- a/lib/steps/microsoft/start-provisioning/check.ts
+++ b/lib/steps/microsoft/start-provisioning/check.ts
@@ -1,6 +1,7 @@
 import { OUTPUT_KEYS } from "@/lib/types";
 import { createStepCheck } from "../../utils/check-factory";
 import { checkMicrosoftProvisioningJobDetails } from "../utils/common-checks";
+import { getRequiredOutput } from "../../utils/get-output";
 
 export const checkStartProvisioning = createStepCheck({
   requiredOutputs: [
@@ -8,10 +9,11 @@ export const checkStartProvisioning = createStepCheck({
     OUTPUT_KEYS.PROVISIONING_JOB_ID,
   ],
   checkLogic: async (context) => {
-    const spId = context.outputs[
-      OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID
-    ] as string;
-    const jobId = context.outputs[OUTPUT_KEYS.PROVISIONING_JOB_ID] as string;
+    const spId = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID,
+    );
+    const jobId = getRequiredOutput<string>(context, OUTPUT_KEYS.PROVISIONING_JOB_ID);
     const result = await checkMicrosoftProvisioningJobDetails(spId, jobId);
     if (result.completed && result.outputs?.provisioningJobState === "Active") {
       return { completed: true, message: "Provisioning job is active." };

--- a/lib/steps/microsoft/start-provisioning/execute.ts
+++ b/lib/steps/microsoft/start-provisioning/execute.ts
@@ -5,6 +5,7 @@ import { portalUrls } from "@/lib/api/url-builder";
 import { getTokens } from "../../utils/auth";
 import { STEP_IDS } from "@/lib/steps/step-refs";
 import { withExecutionHandling } from "../../utils/execute-wrapper";
+import { getRequiredOutput } from "../../utils/get-output";
 
 export const executeStartProvisioning = withExecutionHandling({
   stepId: STEP_IDS.START_PROVISIONING,
@@ -14,10 +15,11 @@ export const executeStartProvisioning = withExecutionHandling({
   ],
   executeLogic: async (context: StepContext): Promise<StepExecutionResult> => {
     const { microsoftToken } = await getTokens();
-    const spId = context.outputs[
-      OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID
-    ] as string;
-    const jobId = context.outputs[OUTPUT_KEYS.PROVISIONING_JOB_ID] as string;
+    const spId = getRequiredOutput<string>(
+      context,
+      OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID,
+    );
+    const jobId = getRequiredOutput<string>(context, OUTPUT_KEYS.PROVISIONING_JOB_ID);
 
     await microsoft.startProvisioningJob(microsoftToken, spId, jobId);
 

--- a/lib/steps/utils/get-output.ts
+++ b/lib/steps/utils/get-output.ts
@@ -1,0 +1,13 @@
+import type { StepContext } from "@/lib/types";
+
+/**
+ * Retrieve a required output value from the step context with type safety.
+ * Throws an error if the value is undefined or null.
+ */
+export function getRequiredOutput<T>(context: StepContext, key: string): T {
+  const value = context.outputs[key];
+  if (value === undefined || value === null) {
+    throw new Error(`Required output '${key}' is missing`);
+  }
+  return value as T;
+}


### PR DESCRIPTION
## Summary
- add `getRequiredOutput` utility for typed output retrieval
- use `getRequiredOutput` across Google and Microsoft steps for better type safety

## Testing
- `pnpm lint --fix`
- `pnpm type-check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684144daac7083228b199f44989088d2