### PR TITLE
Refactor: centralize step enums

### DIFF
--- a/components/debug-panel.tsx
+++ b/components/debug-panel.tsx
@@ -20,6 +20,7 @@ import {
   toggleDebugPanel,
 } from "@/lib/redux/slices/debug-panel";
 import { cn, isApiDebugEnabled } from "@/lib/utils";
+import { Provider } from "@/lib/constants/enums";
 import { Bug, ChevronDown, ChevronUp, Trash2, X } from "lucide-react";
 
 export function DebugPanel() {
@@ -83,7 +84,7 @@ export function DebugPanel() {
 
       <div className="p-3 border-b">
         <div className="flex gap-2 flex-wrap">
-          {(["all", "google", "microsoft", "errors"] as const).map(
+          {(["all", Provider.GOOGLE, Provider.MICROSOFT, "errors"] as const).map(
             (filterType) => (
               <Button
                 key={filterType}

--- a/components/global-error-modal.tsx
+++ b/components/global-error-modal.tsx
@@ -10,6 +10,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { useAppDispatch, useAppSelector } from "@/hooks/use-redux";
+import { Provider } from "@/lib/constants/enums";
+import type { ProviderValue } from "@/lib/types";
 import {
   clearError,
   selectError,
@@ -49,7 +51,7 @@ export function GlobalErrorModal() {
     | {
         category?: string;
         code?: string;
-        provider?: "google" | "microsoft";
+        provider?: ProviderValue;
       }
     | undefined;
 
@@ -80,7 +82,7 @@ export function GlobalErrorModal() {
           {isAuthError && details?.provider && (
             <p className="mt-2 text-sm text-muted-foreground">
               Provider:{" "}
-              {details.provider === "google"
+              {details.provider === Provider.GOOGLE
                 ? "Google Workspace"
                 : "Microsoft Entra ID"}
             </p>

--- a/components/progress.tsx
+++ b/components/progress.tsx
@@ -10,6 +10,7 @@ import { allStepDefinitions } from "@/lib/steps";
 import { getStepInputs, getStepOutputs } from "@/lib/steps/registry";
 import type { StepId } from "@/lib/steps/step-refs";
 import type { ManagedStep, StepStatusInfo } from "@/lib/types";
+import { StepStatus } from "@/lib/constants/enums";
 import React from "react";
 import { WorkflowStepCard } from "./workflow";
 
@@ -25,17 +26,17 @@ export function ProgressVisualizer({ onExecuteStep }: ProgressVisualizerProps) {
   const managedSteps: ManagedStep[] = React.useMemo(() => {
     return allStepDefinitions.map((definition) => {
       const statusInfo: StepStatusInfo = stepsStatusMap[definition.id] || {
-        status: "pending",
+        status: StepStatus.PENDING,
       };
 
       let effectiveStatus = statusInfo.status;
       if (definition.requires && definition.requires.length > 0) {
         const requirementsMet = definition.requires.every((reqId) => {
           const req = stepsStatusMap[reqId];
-          return req && req.status === "completed";
+          return req && req.status === StepStatus.COMPLETED;
         });
-        if (!requirementsMet && statusInfo.status === "pending") {
-          effectiveStatus = "blocked";
+        if (!requirementsMet && statusInfo.status === StepStatus.PENDING) {
+          effectiveStatus = StepStatus.BLOCKED;
         }
       }
 
@@ -63,7 +64,7 @@ export function ProgressVisualizer({ onExecuteStep }: ProgressVisualizerProps) {
   ];
 
   const getProgress = (steps: ManagedStep[]) => {
-    const completed = steps.filter((s) => s.status === "completed").length;
+    const completed = steps.filter((s) => s.status === StepStatus.COMPLETED).length;
     return steps.length > 0 ? (completed / steps.length) * 100 : 0;
   };
 
@@ -82,7 +83,7 @@ export function ProgressVisualizer({ onExecuteStep }: ProgressVisualizerProps) {
               {cat.label}
               {cat.id !== "all" && (
                 <Badge variant="secondary" className="ml-2 h-5 px-1.5">
-                  {cat.steps.filter((s) => s.status === "completed").length}/
+                  {cat.steps.filter((s) => s.status === StepStatus.COMPLETED).length}/
                   {cat.steps.length}
                 </Badge>
               )}
@@ -98,7 +99,7 @@ export function ProgressVisualizer({ onExecuteStep }: ProgressVisualizerProps) {
               <div className="flex items-center justify-between">
                 <CardTitle className="text-base">Progress</CardTitle>
                 <span className="text-sm text-muted-foreground">
-                  {cat.steps.filter((s) => s.status === "completed").length}/
+                  {cat.steps.filter((s) => s.status === StepStatus.COMPLETED).length}/
                   {cat.steps.length} done
                 </span>
               </div>

--- a/components/workflow/config.ts
+++ b/components/workflow/config.ts
@@ -10,11 +10,10 @@ import {
   Zap,
   type LucideIcon,
 } from "lucide-react";
-import type {
-  StepAutomatability,
-  StepCompletionType,
-  StepStatus,
-} from "./workflow-types";
+import type { StepCompletionType } from "./workflow-types";
+import type { StepAutomatability } from "./workflow-types";
+import type { StepStatus } from "./workflow-types";
+import { StepStatus as StepStatusEnum, Automatability } from "@/lib/constants/enums";
 
 export interface StatusDisplayConfig {
   icon: LucideIcon;
@@ -107,7 +106,7 @@ export function getStatusDisplayConfig(
   status: StepStatus,
   completionType?: StepCompletionType,
 ): StatusDisplayConfig {
-  if (status === "completed") {
+  if (status === StepStatusEnum.COMPLETED) {
     return completionType === "user-marked"
       ? stateConfigMap["completed-user"]
       : stateConfigMap["completed-verified"];
@@ -118,5 +117,5 @@ export function getStatusDisplayConfig(
 export function getAutomatabilityDisplayConfig(
   automatability?: StepAutomatability,
 ): AutomatabilityDisplayConfig {
-  return automatabilityConfigMap[automatability || "manual"];
+  return automatabilityConfigMap[automatability || Automatability.MANUAL];
 }

--- a/components/workflow/index.tsx
+++ b/components/workflow/index.tsx
@@ -9,6 +9,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Card, CardFooter } from "@/components/ui/card";
 import { useAppDispatch } from "@/hooks/use-redux";
+import { StepStatus } from "@/lib/constants/enums";
 import { openAskAdminModal } from "@/lib/redux/slices/modals";
 import {
   markStepComplete as markStepCompleteAction,
@@ -57,9 +58,9 @@ export function WorkflowStepCard({
     [step.automatability],
   );
 
-  const isProcessing = step.status === "in_progress";
-  const isCompleted = step.status === "completed";
-  const isBlocked = step.status === "blocked";
+  const isProcessing = step.status === StepStatus.IN_PROGRESS;
+  const isCompleted = step.status === StepStatus.COMPLETED;
+  const isBlocked = step.status === StepStatus.BLOCKED;
 
   const canExecuteStep = useMemo(() => {
     if (!canRunGlobal || isProcessing || isCompleted || isBlocked) return false;

--- a/components/workflow/step-card-footer-elements.tsx
+++ b/components/workflow/step-card-footer-elements.tsx
@@ -10,6 +10,7 @@ import {
   Zap,
 } from "lucide-react";
 import type { ManagedStep } from "./workflow-types";
+import { Automatability, StepStatus } from "@/lib/constants/enums";
 
 export function BlockedMessage() {
   return (
@@ -35,7 +36,7 @@ export function CompletedButtons({
 }: CompletedButtonsProps) {
   return (
     <>
-      {step.automatability !== "manual" && (
+      {step.automatability !== Automatability.MANUAL && (
         <Button
           variant="outline"
           size="sm"
@@ -45,7 +46,7 @@ export function CompletedButtons({
           <RefreshCw className="mr-1.5 h-3.5 w-3.5" /> Re-run
         </Button>
       )}
-      {step.automatability === "manual" &&
+      {step.automatability === Automatability.MANUAL &&
         step.completionType === "user-marked" && (
           <Button
             variant="outline"
@@ -81,26 +82,26 @@ export function ExecutionButtons({
     <>
       <Button
         size="sm"
-        onClick={step.automatability !== "manual" ? onExecute : onMarkComplete}
+        onClick={step.automatability !== Automatability.MANUAL ? onExecute : onMarkComplete}
         disabled={!canExecute || isProcessing}
-        variant={step.automatability === "manual" ? "outline" : "default"}
+        variant={step.automatability === Automatability.MANUAL ? "outline" : "default"}
       >
         {isProcessing ? (
           <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
-        ) : step.automatability !== "manual" ? (
+        ) : step.automatability !== Automatability.MANUAL ? (
           <Zap className="mr-1.5 h-4 w-4" />
         ) : (
           <UserCheck className="mr-1.5 h-4 w-4" />
         )}
         {isProcessing
           ? "Processing..."
-          : step.automatability !== "manual"
-            ? step.status === "failed"
+          : step.automatability !== Automatability.MANUAL
+            ? step.status === StepStatus.FAILED
               ? "Retry"
               : "Execute"
             : "Mark as Complete"}
       </Button>
-      {step.automatability !== "manual" && step.status !== "failed" && (
+      {step.automatability !== Automatability.MANUAL && step.status !== StepStatus.FAILED && (
         <Button
           variant="link"
           size="sm"

--- a/components/workflow/workflow-types.ts
+++ b/components/workflow/workflow-types.ts
@@ -1,15 +1,9 @@
 export type StepId = import("@/lib/steps/step-refs").StepId;
 
-export type StepStatus =
-  | "completed"
-  | "pending"
-  | "in_progress"
-  | "failed"
-  | "available"
-  | "blocked";
+export type StepStatus = import("@/lib/types").StepStatusValue | "available";
 
 export type StepCompletionType = "server-verified" | "user-marked" | null;
-export type StepAutomatability = "automated" | "supervised" | "manual";
+export type StepAutomatability = import("@/lib/types").AutomatabilityValue;
 
 export type ManagedStep = import("@/lib/types").ManagedStep;
 

--- a/hooks/use-auto-check.ts
+++ b/hooks/use-auto-check.ts
@@ -6,6 +6,7 @@ import type { StepCheckResult } from "@/lib/types";
 import { debounce } from "@/lib/utils";
 import { store } from "@/lib/redux/store";
 import { addApiLog } from "@/lib/redux/slices/debug-panel";
+import { StepStatus } from "@/lib/constants/enums";
 
 /**
  * Automatically checks step status when configuration is available.
@@ -42,8 +43,8 @@ export function useAutoCheck(
         const shouldCheck =
           force ||
           !checkedSteps.current.has(stepId) ||
-          status?.status === "failed" ||
-          status?.status === "pending";
+          status?.status === StepStatus.FAILED ||
+          status?.status === StepStatus.PENDING;
 
         if (shouldCheck && !recentlyChecked) {
           console.log(`[AutoCheck] Checking step ${stepId}`);

--- a/hooks/use-step-execution.ts
+++ b/hooks/use-step-execution.ts
@@ -7,6 +7,7 @@ import {
   updateStep,
 } from "@/lib/redux/slices/setup-steps";
 import { allStepDefinitions } from "@/lib/steps";
+import { StepStatus } from "@/lib/constants/enums";
 import type { StepId } from "@/lib/steps/step-refs";
 import { useCallback } from "react";
 import { useAppDispatch, useAppSelector } from "./use-redux";
@@ -29,7 +30,7 @@ export function useStepExecution() {
       dispatch(
         updateStep({
           id: stepId,
-          status: "in_progress",
+          status: StepStatus.IN_PROGRESS,
           error: null,
           message: undefined,
         }),
@@ -58,7 +59,7 @@ export function useStepExecution() {
           dispatch(
             updateStep({
               id: stepId,
-              status: "completed",
+              status: StepStatus.COMPLETED,
               completionType: "server-verified",
               message: result.message,
               metadata: {
@@ -76,7 +77,7 @@ export function useStepExecution() {
           dispatch(
             updateStep({
               id: stepId,
-              status: "failed",
+              status: StepStatus.FAILED,
               error: errorMessage,
               message: result.message,
               metadata: result.outputs || {},
@@ -95,7 +96,7 @@ export function useStepExecution() {
         dispatch(
           updateStep({
             id: stepId,
-            status: "failed",
+            status: StepStatus.FAILED,
             error: errorMessage,
             lastCheckedAt: new Date().toISOString(),
           }),

--- a/lib/api/api-logger.ts
+++ b/lib/api/api-logger.ts
@@ -1,5 +1,6 @@
 import type { ApiLogEntry } from "@/lib/redux/slices/debug-panel";
 import { isApiDebugEnabled } from "@/lib/utils";
+import { Provider } from "@/lib/constants/enums";
 
 export class ApiLogger {
   private logs: ApiLogEntry[] = [];
@@ -83,13 +84,13 @@ export class ApiLogger {
     }
   }
 
-  private detectProvider(url: string): "google" | "microsoft" | "other" {
+  private detectProvider(url: string): typeof Provider[keyof typeof Provider] | "other" {
     if (
       url.startsWith(process.env.GOOGLE_API_BASE!) ||
       url.startsWith(process.env.GOOGLE_IDENTITY_BASE!)
     )
-      return "google";
-    if (url.startsWith(process.env.GRAPH_API_BASE!)) return "microsoft";
+      return Provider.GOOGLE;
+    if (url.startsWith(process.env.GRAPH_API_BASE!)) return Provider.MICROSOFT;
     return "other";
   }
 }

--- a/lib/api/auth-interceptor.ts
+++ b/lib/api/auth-interceptor.ts
@@ -1,11 +1,13 @@
 import { APIError } from "./utils";
 import { auth } from "@/app/(auth)/auth";
 import { ApiLogger } from "./api-logger";
+import type { ProviderValue } from "@/lib/types";
+import { Provider } from "@/lib/constants/enums";
 
 export class AuthenticationError extends APIError {
   constructor(
     message: string,
-    public provider: "google" | "microsoft",
+    public provider: ProviderValue,
     public originalError?: unknown,
   ) {
     super(message, 401, "AUTH_EXPIRED");
@@ -67,11 +69,11 @@ export function isAuthenticationError(
 
 export function wrapAuthError(
   error: unknown,
-  provider: "google" | "microsoft",
+  provider: ProviderValue,
 ): AuthenticationError {
   if (error instanceof APIError && error.status === 401) {
     return new AuthenticationError(
-      `${provider === "google" ? "Google Workspace" : "Microsoft"} authentication expired. Please sign in again.`,
+      `${provider === Provider.GOOGLE ? "Google Workspace" : "Microsoft"} authentication expired. Please sign in again.`,
       provider,
       error,
     );
@@ -85,14 +87,14 @@ export function wrapAuthError(
 export async function fetchWithAuth(
   url: string,
   options: RequestInit = {},
-  provider: "google" | "microsoft",
+  provider: ProviderValue,
   logger?: ApiLogger,
 ): Promise<Response> {
   const session = await auth();
 
   // Select the correct token based on the provider
   const token =
-    provider === "google" ? session?.googleToken : session?.microsoftToken;
+    provider === Provider.GOOGLE ? session?.googleToken : session?.microsoftToken;
 
   if (!token) {
     throw new AuthenticationError(

--- a/lib/api/google.ts
+++ b/lib/api/google.ts
@@ -6,6 +6,7 @@ import {
 } from "./api-enablement-error";
 import type { ApiLogger } from "./api-logger";
 import { wrapAuthError } from "./auth-interceptor";
+import { Provider } from "@/lib/constants/enums";
 import {
   API_BASES,
   googleDirectoryUrls,
@@ -97,7 +98,7 @@ function handleGoogleError(error: unknown): never {
     (error.status === 401 ||
       error.message?.includes("invalid authentication credentials"))
   ) {
-    throw wrapAuthError(error, "google");
+    throw wrapAuthError(error, Provider.GOOGLE);
   }
 
   // Handle API enablement errors specially

--- a/lib/api/session-validator.ts
+++ b/lib/api/session-validator.ts
@@ -1,11 +1,12 @@
 import { auth } from "@/app/(auth)/auth";
+import { Provider } from "@/lib/constants/enums";
 
 export interface SessionValidation {
   valid: boolean;
   googleValid: boolean;
   microsoftValid: boolean;
   error?: {
-    provider: "google" | "microsoft" | "both";
+    provider: (typeof Provider)[keyof typeof Provider] | "both";
     message: string;
     code?: string;
   };
@@ -32,8 +33,8 @@ export async function validateSessionTokens(): Promise<SessionValidation> {
       const missingProvider = !session.googleToken
         ? !session.microsoftToken
           ? "both"
-          : "google"
-        : "microsoft";
+          : Provider.GOOGLE
+        : Provider.MICROSOFT;
 
       return {
         valid: false,
@@ -55,8 +56,8 @@ export async function validateSessionTokens(): Promise<SessionValidation> {
       const missingProvider = !googleValid
         ? !microsoftValid
           ? "both"
-          : "google"
-        : "microsoft";
+          : Provider.GOOGLE
+        : Provider.MICROSOFT;
 
       return {
         valid: false,
@@ -67,7 +68,7 @@ export async function validateSessionTokens(): Promise<SessionValidation> {
           message:
             missingProvider === "both"
               ? "Both providers authentication required"
-              : missingProvider === "google"
+              : missingProvider === Provider.GOOGLE
                 ? "Please sign in with Google"
                 : "Please sign in with Microsoft",
           code: "AUTH_MISSING",

--- a/lib/constants/enums.ts
+++ b/lib/constants/enums.ts
@@ -1,0 +1,18 @@
+export const StepStatus = {
+  PENDING: 'pending',
+  IN_PROGRESS: 'in_progress',
+  COMPLETED: 'completed',
+  FAILED: 'failed',
+  BLOCKED: 'blocked'
+} as const;
+
+export const Provider = {
+  GOOGLE: 'google',
+  MICROSOFT: 'microsoft'
+} as const;
+
+export const Automatability = {
+  AUTOMATED: 'automated',
+  SUPERVISED: 'supervised',
+  MANUAL: 'manual'
+} as const;

--- a/lib/error-handling/error-manager.ts
+++ b/lib/error-handling/error-manager.ts
@@ -2,6 +2,7 @@ import { AuthenticationError } from "@/lib/api/auth-interceptor";
 import { APIError } from "@/lib/api/utils";
 import { setError } from "@/lib/redux/slices/errors";
 import { store } from "@/lib/redux/store";
+import type { ProviderValue } from "@/lib/types";
 
 export type ErrorCategory = "auth" | "api" | "validation" | "system";
 
@@ -9,7 +10,7 @@ export interface ManagedError {
   category: ErrorCategory;
   message: string;
   code?: string;
-  provider?: "google" | "microsoft";
+  provider?: ProviderValue;
   recoverable: boolean;
 }
 

--- a/lib/redux/slices/debug-panel.ts
+++ b/lib/redux/slices/debug-panel.ts
@@ -1,4 +1,5 @@
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import type { ProviderValue } from "@/lib/types";
 
 export interface ApiLogEntry {
   id: string;
@@ -11,7 +12,7 @@ export interface ApiLogEntry {
   responseBody?: unknown;
   error?: string;
   duration?: number;
-  provider?: "google" | "microsoft" | "other";
+  provider?: ProviderValue | "other";
 }
 
 export interface AppErrorLogEntry {
@@ -27,7 +28,7 @@ export interface DebugPanelState {
   isOpen: boolean;
   logs: ApiLogEntry[];
   maxLogs: number;
-  filter: "all" | "google" | "microsoft" | "errors";
+  filter: "all" | ProviderValue | "errors";
 }
 
 const initialState: DebugPanelState = {

--- a/lib/redux/slices/setup-steps.ts
+++ b/lib/redux/slices/setup-steps.ts
@@ -1,4 +1,5 @@
 import type { StepStatusInfo } from "@/lib/types";
+import { StepStatus } from "@/lib/constants/enums";
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 
 interface SetupStepsState {
@@ -25,7 +26,7 @@ export const setupStepsSlice = createSlice({
     /** Updates the status and metadata of a single step. */
     updateStep(state, action: PayloadAction<{ id: string } & StepStatusInfo>) {
       const { id, ...statusInfo } = action.payload;
-      const existingStep = state.steps[id] ?? { status: "pending" };
+      const existingStep = state.steps[id] ?? { status: StepStatus.PENDING };
       state.steps[id] = { ...existingStep, ...statusInfo };
     },
     markStepComplete(
@@ -35,7 +36,7 @@ export const setupStepsSlice = createSlice({
       const { id, isUserMarked } = action.payload;
       state.steps[id] = {
         ...state.steps[id],
-        status: "completed",
+        status: StepStatus.COMPLETED,
         completionType: isUserMarked ? "user-marked" : "server-verified",
       };
       if (isUserMarked) {
@@ -46,7 +47,7 @@ export const setupStepsSlice = createSlice({
       const id = action.payload;
       state.steps[id] = {
         ...state.steps[id],
-        status: "pending",
+        status: StepStatus.PENDING,
         completionType: undefined,
       };
       state.userCompletions[id] = false;

--- a/lib/steps/microsoft/assign-users-sso/index.ts
+++ b/lib/steps/microsoft/assign-users-sso/index.ts
@@ -4,6 +4,7 @@ import { portalUrls } from "@/lib/api/url-builder";
 import { checkAssignUsers } from "./check";
 import { executeAssignUsers } from "./execute";
 import { STEP_IDS } from "@/lib/steps/step-refs";
+import { Automatability } from "@/lib/constants/enums";
 
 export const M9_OUTPUTS: StepOutput[] = [];
 
@@ -39,7 +40,7 @@ export const m9AssignUsersSso: StepDefinition = {
   activity: "SSO",
   provider: "Microsoft",
 
-  automatability: "manual",
+  automatability: Automatability.MANUAL,
   automatable: true,
 
   inputs: M9_INPUTS,

--- a/lib/steps/microsoft/authorize-provisioning/index.ts
+++ b/lib/steps/microsoft/authorize-provisioning/index.ts
@@ -4,6 +4,7 @@ import { portalUrls } from "@/lib/api/url-builder";
 import { checkAuthorizeProvisioning } from "./check";
 import { executeAuthorizeProvisioning } from "./execute";
 import { STEP_IDS } from "@/lib/steps/step-refs";
+import { Automatability } from "@/lib/constants/enums";
 
 export const M3_OUTPUTS: StepOutput[] = [
   {
@@ -37,7 +38,7 @@ export const m3AuthorizeProvisioning: StepDefinition = {
   activity: "Provisioning",
   provider: "Microsoft",
 
-  automatability: "manual",
+  automatability: Automatability.MANUAL,
   automatable: false,
   inputs: M3_INPUTS,
   outputs: M3_OUTPUTS,

--- a/lib/steps/microsoft/configure-attribute-mappings/index.ts
+++ b/lib/steps/microsoft/configure-attribute-mappings/index.ts
@@ -4,6 +4,7 @@ import { portalUrls } from "@/lib/api/url-builder";
 import { checkAttributeMappings } from "./check";
 import { executeConfigureAttributeMappings } from "./execute";
 import { STEP_IDS } from "@/lib/steps/step-refs";
+import { Automatability } from "@/lib/constants/enums";
 
 export const M4_OUTPUTS: StepOutput[] = [
   {
@@ -53,7 +54,7 @@ export const m4ConfigureAttributeMappings: StepDefinition = {
   activity: "Provisioning",
   provider: "Microsoft",
 
-  automatability: "manual",
+  automatability: Automatability.MANUAL,
   automatable: true,
   inputs: M4_INPUTS,
   outputs: M4_OUTPUTS,

--- a/lib/steps/microsoft/configure-saml-app/index.ts
+++ b/lib/steps/microsoft/configure-saml-app/index.ts
@@ -4,6 +4,7 @@ import { portalUrls } from "@/lib/api/url-builder";
 import { checkConfigureSamlApp } from "./check";
 import { executeConfigureSamlApp } from "./execute";
 import { STEP_IDS } from "@/lib/steps/step-refs";
+import { Automatability } from "@/lib/constants/enums";
 
 export const M7_OUTPUTS: StepOutput[] = [
   {
@@ -71,7 +72,7 @@ export const m7ConfigureSamlApp: StepDefinition = {
   activity: "SSO",
   provider: "Microsoft",
 
-  automatability: "manual",
+  automatability: Automatability.MANUAL,
   automatable: true,
 
   inputs: M7_INPUTS,

--- a/lib/steps/microsoft/test-sso/index.ts
+++ b/lib/steps/microsoft/test-sso/index.ts
@@ -4,6 +4,7 @@ import { portalUrls } from "@/lib/api/url-builder";
 import { checkTestSso } from "./check";
 import { executeTestSso } from "./execute";
 import { STEP_IDS } from "@/lib/steps/step-refs";
+import { Automatability } from "@/lib/constants/enums";
 
 export const M10_OUTPUTS: StepOutput[] = [
   { key: OUTPUT_KEYS.FLAG_M10_SSO_TESTED, description: "SSO tested" },
@@ -32,7 +33,7 @@ export const m10TestSso: StepDefinition = {
   activity: "SSO",
   provider: "Microsoft",
 
-  automatability: "manual",
+  automatability: Automatability.MANUAL,
   automatable: false,
 
   inputs: M10_INPUTS,

--- a/lib/steps/utils/error-handling.ts
+++ b/lib/steps/utils/error-handling.ts
@@ -32,7 +32,7 @@ export function handleCheckError(
         method: "AUTH_ERROR",
         url: error.provider || "unknown",
         error: `Authentication Error: ${error.message}`,
-        provider: error.provider === "google" ? "google" : "microsoft",
+        provider: error.provider,
       }),
     );
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,8 +2,15 @@
  * Defines the dynamic status and metadata of a step, typically stored in Redux.
  */
 import type { ApiLogger } from "./api/api-logger";
+import { Automatability, Provider, StepStatus } from "./constants/enums";
+
+export type StepStatusValue =
+  (typeof StepStatus)[keyof typeof StepStatus];
+export type ProviderValue = (typeof Provider)[keyof typeof Provider];
+export type AutomatabilityValue =
+  (typeof Automatability)[keyof typeof Automatability];
 export interface StepStatusInfo {
-  status: "pending" | "in_progress" | "completed" | "failed" | "blocked";
+  status: StepStatusValue;
   completionType?: "server-verified" | "user-marked";
   error?: string | null;
   message?: string;
@@ -45,7 +52,7 @@ export interface StepCheckResult {
     responseBody?: unknown;
     error?: string;
     duration?: number;
-    provider?: "google" | "microsoft" | "other";
+    provider?: ProviderValue | "other";
   }>;
 }
 
@@ -72,7 +79,7 @@ export interface StepExecutionResult {
     responseBody?: unknown;
     error?: string;
     duration?: number;
-    provider?: "google" | "microsoft" | "other";
+    provider?: ProviderValue | "other";
   }>;
 }
 
@@ -125,7 +132,7 @@ export interface StepDefinition {
   provider: "Google" | "Microsoft";
 
   // Execution characteristics
-  automatability: "automated" | "supervised" | "manual";
+  automatability: AutomatabilityValue;
   automatable: boolean; // Keep for backward compatibility, derive from automatability
 
   // Dependencies and flow


### PR DESCRIPTION
## Summary
- introduce `lib/constants/enums.ts` for StepStatus, Provider and Automatability
- type definitions now reference these enums
- replace string status checks with enum constants
- convert step definitions to use Automatability enum

## Testing
- `pnpm lint --fix`
- `pnpm type-check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684145c399648322b288da49c3b13b22