### PR TITLE
Fix Redux selector anti-pattern

### DIFF
--- a/components/auth.tsx
+++ b/components/auth.tsx
@@ -25,7 +25,8 @@ import { useErrorHandler } from "@/hooks/use-error-handler";
  */
 export function AuthStatus() {
   const { data: session, status } = useSession();
-  const { domain, tenantId } = useAppSelector((state) => state.appConfig);
+  const domain = useAppSelector((state) => state.appConfig.domain);
+  const tenantId = useAppSelector((state) => state.appConfig.tenantId);
   const { handleError } = useErrorHandler();
 
   const isConfigReady = !!domain && !!tenantId;

--- a/components/form.tsx
+++ b/components/form.tsx
@@ -34,9 +34,8 @@ type ConfigFormData = z.infer<typeof configFormSchema>;
  */
 
 export function ConfigForm() {
-  const currentAppConfig = useAppSelector(
-    (state: RootState) => state.appConfig,
-  );
+  const domain = useAppSelector((state: RootState) => state.appConfig.domain);
+  const tenantId = useAppSelector((state: RootState) => state.appConfig.tenantId);
 
   const {
     register,
@@ -45,8 +44,8 @@ export function ConfigForm() {
   } = useForm<ConfigFormData>({
     resolver: zodResolver(configFormSchema),
     defaultValues: {
-      domain: currentAppConfig.domain ?? "",
-      tenantId: currentAppConfig.tenantId ?? "",
+      domain: domain ?? "",
+      tenantId: tenantId ?? "",
     },
   });
 
@@ -54,18 +53,13 @@ export function ConfigForm() {
   useEffect(() => {
     console.log(
       "ConfigForm: Resetting/populating form with Redux state:",
-      currentAppConfig,
+      { domain, tenantId },
     );
     reset({
-      domain: currentAppConfig.domain ?? "",
-      tenantId: currentAppConfig.tenantId ?? "",
+      domain: domain ?? "",
+      tenantId: tenantId ?? "",
     });
-  }, [
-    currentAppConfig,
-    currentAppConfig.domain,
-    currentAppConfig.tenantId,
-    reset,
-  ]);
+  }, [domain, tenantId, reset]);
 
   return (
     <Card className="mb-6">

--- a/components/progress.tsx
+++ b/components/progress.tsx
@@ -19,8 +19,10 @@ interface ProgressVisualizerProps {
 
 export function ProgressVisualizer({ onExecuteStep }: ProgressVisualizerProps) {
   const stepsStatusMap = useAppSelector((state) => state.setupSteps.steps);
-  const appConfig = useAppSelector((state) => state.appConfig);
-  const canRunGlobalSteps = !!(appConfig.domain && appConfig.tenantId);
+  const domain = useAppSelector((state) => state.appConfig.domain);
+  const tenantId = useAppSelector((state) => state.appConfig.tenantId);
+  const outputs = useAppSelector((state) => state.appConfig.outputs);
+  const canRunGlobalSteps = !!(domain && tenantId);
 
   const managedSteps: ManagedStep[] = React.useMemo(() => {
     return allStepDefinitions.map((definition) => {
@@ -114,7 +116,7 @@ export function ProgressVisualizer({ onExecuteStep }: ProgressVisualizerProps) {
                 <WorkflowStepCard
                   key={step.id}
                   step={step}
-                  allOutputs={appConfig.outputs}
+                  allOutputs={outputs}
                   onExecute={onExecuteStep}
                   canRunGlobal={canRunGlobalSteps}
                   stepInputDefs={getStepInputs(

--- a/hooks/use-auto-check.ts
+++ b/hooks/use-auto-check.ts
@@ -14,7 +14,8 @@ import { addApiLog } from "@/lib/redux/slices/debug-panel";
 export function useAutoCheck(
   executeCheck: (stepId: StepId) => Promise<StepCheckResult>,
 ) {
-  const appConfig = useAppSelector((state) => state.appConfig);
+  const domain = useAppSelector((state) => state.appConfig.domain);
+  const tenantId = useAppSelector((state) => state.appConfig.tenantId);
   const stepsStatus = useAppSelector((state) => state.setupSteps.steps);
 
   const checkedSteps = useRef(new Set<StepId>());
@@ -24,7 +25,7 @@ export function useAutoCheck(
   const runChecks = useCallback(
     async (force = false) => {
       if (isCheckingRef.current) return;
-      if (!appConfig.domain || !appConfig.tenantId) return;
+      if (!domain || !tenantId) return;
 
       isCheckingRef.current = true;
       setIsChecking(true);
@@ -66,16 +67,16 @@ export function useAutoCheck(
       isCheckingRef.current = false;
       setIsChecking(false);
     },
-    [executeCheck, appConfig.domain, appConfig.tenantId, stepsStatus],
+    [executeCheck, domain, tenantId, stepsStatus],
   );
 
   const debouncedRunChecks = useRef(debounce(() => runChecks(false), 5000));
 
   useEffect(() => {
-    if (appConfig.domain && appConfig.tenantId) {
+    if (domain && tenantId) {
       debouncedRunChecks.current();
     }
-  }, [appConfig.domain, appConfig.tenantId]);
+  }, [domain, tenantId]);
 
   const manualRefresh = useCallback(async () => {
     checkedSteps.current.clear();

--- a/hooks/use-session-state.ts
+++ b/hooks/use-session-state.ts
@@ -18,23 +18,21 @@ interface SessionState {
 export function useSessionState(): SessionState {
   const { data: session, status, update } = useSession();
   const dispatch = useAppDispatch();
-  const appConfig = useAppSelector((state) => state.appConfig);
+  const domain = useAppSelector((state) => state.appConfig.domain);
+  const tenantId = useAppSelector((state) => state.appConfig.tenantId);
   const lastValidation = useRef<number>(Date.now());
 
   useEffect(() => {
-    if (
-      session?.authFlowDomain &&
-      session.authFlowDomain !== appConfig.domain
-    ) {
+    if (session?.authFlowDomain && session.authFlowDomain !== domain) {
       dispatch(setDomain(session.authFlowDomain));
     }
     if (
       session?.microsoftTenantId &&
-      session.microsoftTenantId !== appConfig.tenantId
+      session.microsoftTenantId !== tenantId
     ) {
       dispatch(setTenantId(session.microsoftTenantId));
     }
-  }, [session, dispatch, appConfig.domain, appConfig.tenantId]);
+  }, [session, dispatch, domain, tenantId]);
 
   useEffect(() => {
     const interval = setInterval(async () => {

--- a/hooks/use-session-sync.ts
+++ b/hooks/use-session-sync.ts
@@ -15,7 +15,8 @@ export function useSessionSync() {
   const dispatch = useAppDispatch();
   const { handleError } = useErrorHandler();
   const lastCheckRef = useRef<number>(Date.now());
-  const appConfig = useAppSelector((state) => state.appConfig);
+  const domain = useAppSelector((state) => state.appConfig.domain);
+  const tenantId = useAppSelector((state) => state.appConfig.tenantId);
 
   useEffect(() => {
     const checkInterval = setInterval(async () => {
@@ -35,14 +36,14 @@ export function useSessionSync() {
 
   useEffect(() => {
     if (session && status === "authenticated") {
-      if (session.authFlowDomain && !appConfig.domain) {
+      if (session.authFlowDomain && !domain) {
         console.log(
           "Syncing domain from session to Redux:",
           session.authFlowDomain,
         );
         dispatch(setDomain(session.authFlowDomain));
       }
-      if (session.microsoftTenantId && !appConfig.tenantId) {
+      if (session.microsoftTenantId && !tenantId) {
         console.log(
           "Syncing tenant from session to Redux:",
           session.microsoftTenantId,
@@ -50,7 +51,7 @@ export function useSessionSync() {
         dispatch(setTenantId(session.microsoftTenantId));
       }
     }
-  }, [session, status, appConfig.domain, appConfig.tenantId, dispatch]);
+  }, [session, status, domain, tenantId, dispatch]);
 
   return { session, status };
 }

--- a/hooks/use-step-execution.ts
+++ b/hooks/use-step-execution.ts
@@ -13,7 +13,9 @@ import { useAppDispatch, useAppSelector } from "./use-redux";
 
 export function useStepExecution() {
   const dispatch = useAppDispatch();
-  const appConfig = useAppSelector((state) => state.appConfig);
+  const domain = useAppSelector((state) => state.appConfig.domain);
+  const tenantId = useAppSelector((state) => state.appConfig.tenantId);
+  const outputs = useAppSelector((state) => state.appConfig.outputs);
 
   const executeStep = useCallback(
     async (stepId: StepId) => {
@@ -37,9 +39,9 @@ export function useStepExecution() {
 
       try {
         const context = {
-          domain: appConfig.domain!,
-          tenantId: appConfig.tenantId!,
-          outputs: appConfig.outputs,
+          domain: domain!,
+          tenantId: tenantId!,
+          outputs,
         };
 
         const result = await executeStepAction(stepId, context);
@@ -106,7 +108,7 @@ export function useStepExecution() {
         });
       }
     },
-    [dispatch, appConfig],
+    [dispatch, domain, tenantId, outputs],
   );
 
   return { executeStep };


### PR DESCRIPTION
## Summary
- avoid selecting whole `appConfig` state slice in components and hooks
- select individual `domain`, `tenantId`, and `outputs` values

## Testing
- `pnpm lint --fix`
- `pnpm type-check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6841461703e08322b758a828a25bf12a