### PR TITLE
Optimize imports and enable lazy-loaded steps

### DIFF
--- a/app/actions/step-actions.ts
+++ b/app/actions/step-actions.ts
@@ -3,7 +3,6 @@
 import { auth } from "@/app/(auth)/auth";
 import { isAuthenticationError } from "@/lib/api/auth-interceptor";
 import { ApiLogger } from "@/lib/api/api-logger";
-import { allStepDefinitions } from "@/lib/steps";
 import type { StepId } from "@/lib/steps/step-refs";
 import type {
   StepCheckResult,
@@ -12,7 +11,8 @@ import type {
   StepDefinition,
 } from "@/lib/types";
 
-function getStep(stepId: StepId): StepDefinition | undefined {
+async function getStep(stepId: StepId): Promise<StepDefinition | undefined> {
+  const { allStepDefinitions } = await import("@/lib/steps");
   return allStepDefinitions.find((s) => s.id === stepId);
 }
 
@@ -43,7 +43,7 @@ export async function executeStepCheck(
     const sessionValidation = await validateSession();
     if (!sessionValidation.valid) return sessionValidation.error!;
 
-    const step = getStep(stepId);
+    const step = await getStep(stepId);
     if (!step?.check) {
       return { completed: false, message: "No check logic for this step." };
     }
@@ -102,7 +102,7 @@ export async function executeStepAction(
       };
     }
 
-    const step = getStep(stepId);
+    const step = await getStep(stepId);
     if (!step?.execute) {
       return {
         success: false,

--- a/hooks/use-auto-check.ts
+++ b/hooks/use-auto-check.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAppSelector } from "./use-redux";
-import { allStepDefinitions } from "@/lib/steps";
 import type { StepId } from "@/lib/steps/step-refs";
 import type { StepCheckResult } from "@/lib/types";
 import { debounce } from "@/lib/utils";
@@ -29,6 +28,7 @@ export function useAutoCheck(
       isCheckingRef.current = true;
       setIsChecking(true);
 
+      const { allStepDefinitions } = await import("@/lib/steps");
       const checkableSteps = allStepDefinitions
         .filter((s) => s.check)
         .map((s) => s.id as StepId);

--- a/hooks/use-step-execution.ts
+++ b/hooks/use-step-execution.ts
@@ -6,7 +6,6 @@ import {
   clearCheckTimestamp,
   updateStep,
 } from "@/lib/redux/slices/setup-steps";
-import { allStepDefinitions } from "@/lib/steps";
 import type { StepId } from "@/lib/steps/step-refs";
 import { useCallback } from "react";
 import { useAppDispatch, useAppSelector } from "./use-redux";
@@ -17,6 +16,7 @@ export function useStepExecution() {
 
   const executeStep = useCallback(
     async (stepId: StepId) => {
+      const { allStepDefinitions } = await import("@/lib/steps");
       const definition = allStepDefinitions.find((s) => s.id === stepId);
       if (!definition) {
         ErrorManager.dispatch(new Error(`Step ${stepId} not found`), {

--- a/lib/redux/persistence.ts
+++ b/lib/redux/persistence.ts
@@ -41,7 +41,7 @@ export function saveProgress(
  * @param domain The primary domain, used as part of the localStorage key.
  * @returns The persisted progress data, or null if not found.
  */
-export function loadProgress(domain: string): PersistedProgress | null {
+export async function loadProgress(domain: string): Promise<PersistedProgress | null> {
   if (typeof window === "undefined" || !domain) return null;
   try {
     const key = getStorageKey(domain);
@@ -50,8 +50,7 @@ export function loadProgress(domain: string): PersistedProgress | null {
     const parsed = JSON.parse(savedData) as PersistedProgress;
 
     // Import step definitions to check which steps are checkable
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { allStepDefinitions } = require("@/lib/steps");
+    const { allStepDefinitions } = await import("@/lib/steps");
 
     // Filter out checkable steps from persisted state
     const filteredSteps: Record<string, StepStatusInfo> = {};

--- a/lib/steps/google/assign-saml-profile/check.ts
+++ b/lib/steps/google/assign-saml-profile/check.ts
@@ -1,7 +1,12 @@
 import { OUTPUT_KEYS } from "@/lib/types";
 import { createStepCheck } from "../../utils/check-factory";
 import { getGoogleToken } from "../../utils/auth";
-import * as google from "@/lib/api/google";
+import {
+  getSamlProfile,
+  listSamlProfiles,
+  listIdpCredentials,
+  type InboundSamlSsoProfile,
+} from "@/lib/api/google";
 import { portalUrls } from "@/lib/api/url-builder";
 import { handleCheckError } from "../../utils/error-handling";
 
@@ -13,15 +18,15 @@ export const checkAssignSamlProfile = createStepCheck({
     ] as string;
     try {
       const token = await getGoogleToken();
-      let profile: google.InboundSamlSsoProfile | null = null;
+      let profile: InboundSamlSsoProfile | null = null;
       if (profileName.startsWith("inboundSamlSsoProfiles/")) {
-        profile = await google.getSamlProfile(
+        profile = await getSamlProfile(
           token,
           profileName,
           context.logger,
         );
       } else {
-        const profiles = await google.listSamlProfiles(token, context.logger);
+        const profiles = await listSamlProfiles(token, context.logger);
         profile = profiles.find((p) => p.displayName === profileName) ?? null;
       }
       if (!profile?.name) {
@@ -45,7 +50,7 @@ export const checkAssignSamlProfile = createStepCheck({
         outputs[OUTPUT_KEYS.GOOGLE_SAML_SP_ACS_URL] =
           profile.spConfig.assertionConsumerServiceUri;
       }
-      const idpCreds = await google.listIdpCredentials(
+      const idpCreds = await listIdpCredentials(
         token,
         profile.name,
         context.logger,

--- a/lib/steps/google/assign-saml-profile/execute.ts
+++ b/lib/steps/google/assign-saml-profile/execute.ts
@@ -1,4 +1,4 @@
-import * as google from "@/lib/api/google";
+import { assignSamlToOrgUnits } from "@/lib/api/google";
 import type { StepContext, StepExecutionResult } from "@/lib/types";
 import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
@@ -15,7 +15,7 @@ export const executeAssignSamlProfile = withExecutionHandling({
       OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME
     ] as string;
 
-    await google.assignSamlToOrgUnits(
+    await assignSamlToOrgUnits(
       token,
       profileFullName,
       [{ orgUnitId: "/", ssoMode: "SAML_SSO_ENABLED" }],

--- a/lib/steps/google/create-automation-ou/check.ts
+++ b/lib/steps/google/create-automation-ou/check.ts
@@ -1,5 +1,5 @@
 import { OUTPUT_KEYS } from "@/lib/types";
-import * as google from "@/lib/api/google";
+import { getOrgUnit } from "@/lib/api/google";
 import { portalUrls } from "@/lib/api/url-builder";
 import { getGoogleToken } from "../../utils/auth";
 import { createStepCheck } from "../../utils/check-factory";
@@ -11,7 +11,7 @@ export const checkAutomationOu = createStepCheck({
   checkLogic: async (_context) => {
     try {
       const token = await getGoogleToken();
-      const orgUnit = await google.getOrgUnit(token, "/Automation");
+      const orgUnit = await getOrgUnit(token, "/Automation");
       if (orgUnit?.orgUnitId && orgUnit.orgUnitPath) {
         return {
           completed: true,

--- a/lib/steps/google/create-automation-ou/execute.ts
+++ b/lib/steps/google/create-automation-ou/execute.ts
@@ -1,4 +1,4 @@
-import * as google from "@/lib/api/google";
+import { createOrgUnit, getOrgUnit, type GoogleOrgUnit } from "@/lib/api/google";
 import type { StepContext, StepExecutionResult } from "@/lib/types";
 import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
@@ -38,9 +38,9 @@ export const executeCreateAutomationOu = withExecutionHandling({
       };
     }
 
-    let created: google.GoogleOrgUnit;
+    let created: GoogleOrgUnit;
     try {
-      created = await google.createOrgUnit(
+      created = await createOrgUnit(
         token,
         ouName,
         parentPath,
@@ -49,7 +49,7 @@ export const executeCreateAutomationOu = withExecutionHandling({
       );
     } catch (error) {
       if (error instanceof AlreadyExistsError) {
-        const existing = await google.getOrgUnit(
+        const existing = await getOrgUnit(
           token,
           `${parentPath}${ouName}`,
           context.logger,

--- a/lib/steps/google/create-provisioning-user/check.ts
+++ b/lib/steps/google/create-provisioning-user/check.ts
@@ -1,6 +1,6 @@
 import { OUTPUT_KEYS } from "@/lib/types";
 import { createStepCheck } from "../../utils/check-factory";
-import * as google from "@/lib/api/google";
+import { getUser } from "@/lib/api/google";
 import { APIError } from "@/lib/api/utils";
 import { getGoogleToken } from "../../utils/auth";
 import { handleCheckError } from "../../utils/error-handling";
@@ -15,7 +15,7 @@ export const checkProvisioningUser = createStepCheck({
     try {
       const token = await getGoogleToken();
       const email = `azuread-provisioning@${context.domain}`;
-      const user = await google.getUser(token, email, context.logger);
+      const user = await getUser(token, email, context.logger);
       if (user?.primaryEmail) {
         return {
           completed: true,

--- a/lib/steps/google/create-provisioning-user/execute.ts
+++ b/lib/steps/google/create-provisioning-user/execute.ts
@@ -1,4 +1,4 @@
-import * as google from "@/lib/api/google";
+import { createUser, getUser, type DirectoryUser } from "@/lib/api/google";
 import type { StepContext, StepExecutionResult } from "@/lib/types";
 import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
@@ -17,7 +17,7 @@ export const executeCreateProvisioningUser = withExecutionHandling({
 
     const email = `azuread-provisioning@${domain}`;
     const tempPassword = `P@${Date.now()}w0rd`;
-    const user: google.DirectoryUser = {
+    const user: DirectoryUser = {
       primaryEmail: email,
       name: { givenName: "Microsoft Entra ID", familyName: "Provisioning" },
       password: tempPassword,
@@ -25,12 +25,12 @@ export const executeCreateProvisioningUser = withExecutionHandling({
       changePasswordAtNextLogin: false,
     };
 
-    let result: google.DirectoryUser;
+    let result: DirectoryUser;
     try {
-      result = await google.createUser(token, user, context.logger);
+      result = await createUser(token, user, context.logger);
     } catch (error) {
       if (error instanceof AlreadyExistsError) {
-        const existing = await google.getUser(token, email, context.logger);
+        const existing = await getUser(token, email, context.logger);
         if (existing?.primaryEmail && existing.id) {
           return {
             success: true,

--- a/lib/steps/google/exclude-automation-ou/check.ts
+++ b/lib/steps/google/exclude-automation-ou/check.ts
@@ -1,5 +1,10 @@
 import { OUTPUT_KEYS } from "@/lib/types";
-import * as google from "@/lib/api/google";
+import {
+  getSamlProfile,
+  listSamlProfiles,
+  listIdpCredentials,
+  type InboundSamlSsoProfile,
+} from "@/lib/api/google";
 import { portalUrls } from "@/lib/api/url-builder";
 import { getGoogleToken } from "../../utils/auth";
 import { createStepCheck } from "../../utils/check-factory";
@@ -13,15 +18,15 @@ export const checkExcludeAutomationOu = createStepCheck({
     ] as string;
     try {
       const token = await getGoogleToken();
-      let profile: google.InboundSamlSsoProfile | null = null;
+      let profile: InboundSamlSsoProfile | null = null;
       if (profileName.startsWith("inboundSamlSsoProfiles/")) {
-        profile = await google.getSamlProfile(
+        profile = await getSamlProfile(
           token,
           profileName,
           context.logger,
         );
       } else {
-        const profiles = await google.listSamlProfiles(token, context.logger);
+        const profiles = await listSamlProfiles(token, context.logger);
         profile = profiles.find((p) => p.displayName === profileName) ?? null;
       }
       if (!profile?.name) {
@@ -37,7 +42,7 @@ export const checkExcludeAutomationOu = createStepCheck({
         ssoMode: profile.ssoMode,
         resourceUrl: portalUrls.google.sso.samlProfile(profile.name),
       };
-      const idpCreds = await google.listIdpCredentials(
+      const idpCreds = await listIdpCredentials(
         token,
         profile.name,
         context.logger,

--- a/lib/steps/google/exclude-automation-ou/execute.ts
+++ b/lib/steps/google/exclude-automation-ou/execute.ts
@@ -1,4 +1,4 @@
-import * as google from "@/lib/api/google";
+import { assignSamlToOrgUnits } from "@/lib/api/google";
 import type { StepContext, StepExecutionResult } from "@/lib/types";
 import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
@@ -15,7 +15,7 @@ export const executeExcludeAutomationOu = withExecutionHandling({
       OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME
     ] as string;
 
-    await google.assignSamlToOrgUnits(
+    await assignSamlToOrgUnits(
       token,
       profileFullName,
       [{ orgUnitId: "/Automation", ssoMode: "SSO_OFF" }],

--- a/lib/steps/google/grant-super-admin/check.ts
+++ b/lib/steps/google/grant-super-admin/check.ts
@@ -1,6 +1,6 @@
 import { OUTPUT_KEYS } from "@/lib/types";
 import { createStepCheck } from "../../utils/check-factory";
-import * as google from "@/lib/api/google";
+import { getUser, listRoleAssignments } from "@/lib/api/google";
 import { getGoogleToken } from "../../utils/auth";
 import { handleCheckError } from "../../utils/error-handling";
 
@@ -10,7 +10,7 @@ export const checkSuperAdmin = createStepCheck({
     const email = context.outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL] as string;
     try {
       const token = await getGoogleToken();
-      const user = await google.getUser(token, email, context.logger);
+      const user = await getUser(token, email, context.logger);
       if (!user) {
         return {
           completed: false,
@@ -24,7 +24,7 @@ export const checkSuperAdmin = createStepCheck({
           outputs: { [OUTPUT_KEYS.SUPER_ADMIN_ROLE_ID]: "3" },
         };
       }
-      const roles = await google.listRoleAssignments(
+      const roles = await listRoleAssignments(
         token,
         email,
         context.logger,

--- a/lib/steps/google/grant-super-admin/execute.ts
+++ b/lib/steps/google/grant-super-admin/execute.ts
@@ -1,4 +1,8 @@
-import * as google from "@/lib/api/google";
+import {
+  getUser,
+  listRoleAssignments,
+  assignAdminRole,
+} from "@/lib/api/google";
 import type { StepContext, StepExecutionResult } from "@/lib/types";
 import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
@@ -43,7 +47,7 @@ export const executeGrantSuperAdmin = withExecutionHandling({
         error: { message: "Customer ID not found in previous step." },
       };
     }
-    const user = await google.getUser(token, email);
+    const user = await getUser(token, email);
 
     if (user?.isAdmin) {
       return {
@@ -53,7 +57,7 @@ export const executeGrantSuperAdmin = withExecutionHandling({
         resourceUrl: portalUrls.google.users.details(email),
       };
     }
-    const roles = await google.listRoleAssignments(
+    const roles = await listRoleAssignments(
       token,
       email,
       context.logger,
@@ -67,7 +71,7 @@ export const executeGrantSuperAdmin = withExecutionHandling({
       };
     }
 
-    await google.assignAdminRole(token, email, "3", customerId, context.logger);
+    await assignAdminRole(token, email, "3", customerId, context.logger);
 
     return {
       success: true,

--- a/lib/steps/google/initiate-saml-profile/check.ts
+++ b/lib/steps/google/initiate-saml-profile/check.ts
@@ -1,6 +1,6 @@
 import { OUTPUT_KEYS } from "@/lib/types";
 import { createStepCheck } from "../../utils/check-factory";
-import * as google from "@/lib/api/google";
+import { listSamlProfiles, type InboundSamlSsoProfile } from "@/lib/api/google";
 import { portalUrls } from "@/lib/api/url-builder";
 import { getGoogleToken } from "../../utils/auth";
 import { handleCheckError } from "../../utils/error-handling";
@@ -11,7 +11,7 @@ export const checkSamlProfile = createStepCheck({
     const profileDisplayName = "Azure AD SSO";
     try {
       const token = await getGoogleToken();
-      const profiles = await google.listSamlProfiles(token);
+      const profiles: InboundSamlSsoProfile[] = await listSamlProfiles(token);
       const profile = profiles.find(
         (p) => p.displayName === profileDisplayName,
       );

--- a/lib/steps/google/initiate-saml-profile/execute.ts
+++ b/lib/steps/google/initiate-saml-profile/execute.ts
@@ -1,4 +1,4 @@
-import * as google from "@/lib/api/google";
+import { createSamlProfile, listSamlProfiles } from "@/lib/api/google";
 import type { StepContext, StepExecutionResult } from "@/lib/types";
 import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
@@ -16,10 +16,10 @@ export const executeInitiateSamlProfile = withExecutionHandling({
 
     let result;
     try {
-      result = await google.createSamlProfile(token, profileDisplayName);
+      result = await createSamlProfile(token, profileDisplayName);
     } catch (error) {
       if (error instanceof AlreadyExistsError) {
-        const profiles = await google.listSamlProfiles(token);
+        const profiles = await listSamlProfiles(token);
         const existing = profiles.find(
           (p) => p.displayName === profileDisplayName,
         );

--- a/lib/steps/google/update-saml-profile/check.ts
+++ b/lib/steps/google/update-saml-profile/check.ts
@@ -1,6 +1,11 @@
 import { OUTPUT_KEYS } from "@/lib/types";
 import { createStepCheck } from "../../utils/check-factory";
-import * as google from "@/lib/api/google";
+import {
+  getSamlProfile,
+  listSamlProfiles,
+  listIdpCredentials,
+  type InboundSamlSsoProfile,
+} from "@/lib/api/google";
 import { portalUrls } from "@/lib/api/url-builder";
 import { getGoogleToken } from "../../utils/auth";
 import { handleCheckError } from "../../utils/error-handling";
@@ -19,15 +24,15 @@ export const checkSamlProfileUpdate = createStepCheck({
     ] as string;
     try {
       const token = await getGoogleToken();
-      let profile: google.InboundSamlSsoProfile | null = null;
+      let profile: InboundSamlSsoProfile | null = null;
       if (profileName.startsWith("inboundSamlSsoProfiles/")) {
-        profile = await google.getSamlProfile(
+        profile = await getSamlProfile(
           token,
           profileName,
           context.logger,
         );
       } else {
-        const profiles = await google.listSamlProfiles(token, context.logger);
+        const profiles = await listSamlProfiles(token, context.logger);
         profile = profiles.find((p) => p.displayName === profileName) ?? null;
       }
       if (!profile?.name) {
@@ -51,7 +56,7 @@ export const checkSamlProfileUpdate = createStepCheck({
         outputs[OUTPUT_KEYS.GOOGLE_SAML_SP_ACS_URL] =
           profile.spConfig.assertionConsumerServiceUri;
       }
-      const idpCreds = await google.listIdpCredentials(
+      const idpCreds = await listIdpCredentials(
         token,
         profile.name,
         context.logger,

--- a/lib/steps/google/update-saml-profile/execute.ts
+++ b/lib/steps/google/update-saml-profile/execute.ts
@@ -1,4 +1,4 @@
-import * as google from "@/lib/api/google";
+import { updateSamlProfile, addIdpCredentials } from "@/lib/api/google";
 import type { StepContext, StepExecutionResult } from "@/lib/types";
 import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
@@ -23,7 +23,7 @@ export const executeUpdateSamlProfile = withExecutionHandling({
     const idpEntityId = context.outputs[OUTPUT_KEYS.IDP_ENTITY_ID] as string;
     const cert = context.outputs[OUTPUT_KEYS.IDP_CERTIFICATE_BASE64] as string;
 
-    await google.updateSamlProfile(
+    await updateSamlProfile(
       token,
       profileName,
       {
@@ -35,7 +35,7 @@ export const executeUpdateSamlProfile = withExecutionHandling({
       context.logger,
     );
 
-    await google.addIdpCredentials(token, profileName, cert, context.logger);
+    await addIdpCredentials(token, profileName, cert, context.logger);
 
     return {
       success: true,

--- a/lib/steps/google/verify-domain/check.ts
+++ b/lib/steps/google/verify-domain/check.ts
@@ -1,5 +1,5 @@
 import { createStepCheck } from "../../utils/check-factory";
-import * as google from "@/lib/api/google";
+import { getDomain } from "@/lib/api/google";
 import { getGoogleToken } from "../../utils/auth";
 import { handleCheckError } from "../../utils/error-handling";
 import { APIError } from "@/lib/api/utils";
@@ -12,7 +12,7 @@ export const checkDomain = createStepCheck({
     }
     try {
       const token = await getGoogleToken();
-      const domainDetails = await google.getDomain(
+      const domainDetails = await getDomain(
         token,
         context.domain,
         context.logger,

--- a/lib/steps/google/verify-domain/execute.ts
+++ b/lib/steps/google/verify-domain/execute.ts
@@ -1,4 +1,4 @@
-import * as google from "@/lib/api/google";
+import { getLoggedInUser, addDomain } from "@/lib/api/google";
 import type { StepContext, StepExecutionResult } from "@/lib/types";
 import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
@@ -18,9 +18,9 @@ export const executeVerifyDomain = withExecutionHandling({
     if (!validation.valid) {
       return { success: false, error: validation.error };
     }
-    const user = await google.getLoggedInUser(token);
+    const user = await getLoggedInUser(token);
     try {
-      await google.addDomain(token, context.domain);
+      await addDomain(token, context.domain);
     } catch (error) {
       if (error instanceof AlreadyExistsError) {
         return {

--- a/lib/steps/microsoft/configure-attribute-mappings/execute.ts
+++ b/lib/steps/microsoft/configure-attribute-mappings/execute.ts
@@ -1,4 +1,4 @@
-import * as microsoft from "@/lib/api/microsoft";
+import { configureAttributeMappings } from "@/lib/api/microsoft";
 import type { StepContext, StepExecutionResult } from "@/lib/types";
 import type * as MicrosoftGraph from "microsoft-graph";
 import { OUTPUT_KEYS } from "@/lib/types";
@@ -26,7 +26,7 @@ export const executeConfigureAttributeMappings = withExecutionHandling({
       id: "GoogleApps",
     };
 
-    await microsoft.configureAttributeMappings(
+    await configureAttributeMappings(
       microsoftToken,
       spId,
       jobId,

--- a/lib/steps/microsoft/configure-saml-app/execute.ts
+++ b/lib/steps/microsoft/configure-saml-app/execute.ts
@@ -1,4 +1,4 @@
-import * as microsoft from "@/lib/api/microsoft";
+import { updateApplication, type Application } from "@/lib/api/microsoft";
 import type { StepContext, StepExecutionResult } from "@/lib/types";
 import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
@@ -32,7 +32,7 @@ export const executeConfigureSamlApp = withExecutionHandling({
     ] as string;
     const primaryDomain = context.domain as string;
 
-    const appPatchPayload: Partial<microsoft.Application> = {
+    const appPatchPayload: Partial<Application> = {
       identifierUris: [googleSpEntityId, `https://${primaryDomain}`],
       web: {
         redirectUris: [googleAcsUrl],
@@ -43,7 +43,7 @@ export const executeConfigureSamlApp = withExecutionHandling({
       },
     };
 
-    await microsoft.updateApplication(
+    await updateApplication(
       microsoftToken,
       appObjectId,
       appPatchPayload,

--- a/lib/steps/microsoft/create-provisioning-app/execute.ts
+++ b/lib/steps/microsoft/create-provisioning-app/execute.ts
@@ -1,4 +1,10 @@
-import * as microsoft from "@/lib/api/microsoft";
+import {
+  createEnterpriseApp,
+  listApplications,
+  getServicePrincipalByAppId,
+  type Application,
+  type ServicePrincipal,
+} from "@/lib/api/microsoft";
 import type { StepContext, StepExecutionResult } from "@/lib/types";
 import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
@@ -16,24 +22,24 @@ export const executeCreateProvisioningApp = withExecutionHandling({
     const appName = "Google Workspace User Provisioning";
 
     let result: {
-      application: microsoft.Application;
-      servicePrincipal: microsoft.ServicePrincipal;
+      application: Application;
+      servicePrincipal: ServicePrincipal;
     };
     try {
-      result = await microsoft.createEnterpriseApp(
+      result = await createEnterpriseApp(
         microsoftToken,
         TEMPLATE_ID,
         appName,
       );
     } catch (error) {
       if (error instanceof AlreadyExistsError) {
-        const existingApps = await microsoft.listApplications(
+        const existingApps = await listApplications(
           microsoftToken,
           `displayName eq '${appName}'`,
         );
         const existingApp = existingApps[0];
         if (existingApp?.appId) {
-          const sp = await microsoft.getServicePrincipalByAppId(
+          const sp = await getServicePrincipalByAppId(
             microsoftToken,
             existingApp.appId,
           );

--- a/lib/steps/microsoft/enable-provisioning-sp/execute.ts
+++ b/lib/steps/microsoft/enable-provisioning-sp/execute.ts
@@ -1,4 +1,4 @@
-import * as microsoft from "@/lib/api/microsoft";
+import { patchServicePrincipal } from "@/lib/api/microsoft";
 import type { StepContext, StepExecutionResult } from "@/lib/types";
 import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
@@ -19,7 +19,7 @@ export const executeEnableProvisioningSp = withExecutionHandling({
     ] as string;
     const appId = context.outputs[OUTPUT_KEYS.PROVISIONING_APP_ID] as string;
 
-    await microsoft.patchServicePrincipal(microsoftToken, spId, {
+    await patchServicePrincipal(microsoftToken, spId, {
       accountEnabled: true,
     });
 

--- a/lib/steps/microsoft/retrieve-idp-metadata/execute.ts
+++ b/lib/steps/microsoft/retrieve-idp-metadata/execute.ts
@@ -1,4 +1,4 @@
-import * as microsoft from "@/lib/api/microsoft";
+import { getSamlMetadata } from "@/lib/api/microsoft";
 import type { StepContext, StepExecutionResult } from "@/lib/types";
 import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
@@ -16,7 +16,7 @@ export const executeRetrieveIdpMetadata = withExecutionHandling({
     const { tenantId } = await getTokens();
     const appId = context.outputs[OUTPUT_KEYS.SAML_SSO_APP_ID] as string;
     const spId = context.outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID] as string;
-    const { certificate, ssoUrl, entityId } = await microsoft.getSamlMetadata(
+    const { certificate, ssoUrl, entityId } = await getSamlMetadata(
       tenantId,
       appId,
       context.logger,

--- a/lib/steps/microsoft/start-provisioning/execute.ts
+++ b/lib/steps/microsoft/start-provisioning/execute.ts
@@ -1,4 +1,4 @@
-import * as microsoft from "@/lib/api/microsoft";
+import { startProvisioningJob } from "@/lib/api/microsoft";
 import type { StepContext, StepExecutionResult } from "@/lib/types";
 import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
@@ -19,7 +19,7 @@ export const executeStartProvisioning = withExecutionHandling({
     ] as string;
     const jobId = context.outputs[OUTPUT_KEYS.PROVISIONING_JOB_ID] as string;
 
-    await microsoft.startProvisioningJob(microsoftToken, spId, jobId);
+    await startProvisioningJob(microsoftToken, spId, jobId);
 
     return {
       success: true,


### PR DESCRIPTION
## Summary
- refactor API wrapper imports to use named exports
- lazy load step definitions for better build performance
- update persistence loading to use dynamic import

## Testing
- `pnpm lint --fix`
- `pnpm type-check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6841465723d083229c1161ae558aba25