### PR TITLE
Refactor step definitions with factory

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -8,7 +8,7 @@ if (typeof global.TextEncoder === 'undefined') {
 }
 if (typeof global.TransformStream === 'undefined') {
   const { TransformStream } = require('stream/web')
-  // @ts-ignore
+  // @ts-expect-error stream-web types
   global.TransformStream = TransformStream
 }
 if (typeof global.BroadcastChannel === 'undefined') {
@@ -19,7 +19,7 @@ if (typeof global.BroadcastChannel === 'undefined') {
     addEventListener() {}
     removeEventListener() {}
   }
-  // @ts-ignore
+  // @ts-expect-error BroadcastChannel polyfill
   global.BroadcastChannel = BroadcastChannelMock
 }
 

--- a/lib/steps/google/assign-saml-profile/index.ts
+++ b/lib/steps/google/assign-saml-profile/index.ts
@@ -1,49 +1,38 @@
-import type { StepDefinition, StepInput, StepOutput } from "@/lib/types";
-import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
+import { STEP_IDS } from "@/lib/steps/step-refs";
+import { defineStep } from "@/lib/steps/utils/step-factory";
+import { OUTPUT_KEYS } from "@/lib/types";
 import { checkAssignSamlProfile } from "./check";
 import { executeAssignSamlProfile } from "./execute";
-import { STEP_IDS } from "@/lib/steps/step-refs";
 
-export const G7_OUTPUTS: StepOutput[] = [];
-export const G7_INPUTS: StepInput[] = [
-  {
-    type: "keyValue",
-    data: {
-      key: OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME,
-      description: "Full name of the Google SAML profile",
-      producedBy: STEP_IDS.INITIATE_SAML_PROFILE,
-    },
-    stepTitle: "Initiate Google SAML Profile",
-  },
-];
-
-export const g7AssignSamlProfile: StepDefinition = {
+export const g7AssignSamlProfile = defineStep({
   id: STEP_IDS.ASSIGN_SAML_PROFILE,
-  title: "Assign Google SAML Profile to Users/OUs",
-  description: "Turn on single sign-on for your users",
-  details:
-    "Assigns the created SAML profile to your Organizational Units or user groups so that sign-in requests are redirected to Microsoft. This enables SSO for selected users.",
-
-  category: "SSO",
-  activity: "SSO",
-  provider: "Google",
-
-  automatability: "automated",
-  automatable: true,
-  inputs: G7_INPUTS,
-  outputs: G7_OUTPUTS,
-  requires: [STEP_IDS.UPDATE_SAML_PROFILE],
-  nextStep: {
-    id: STEP_IDS.EXCLUDE_AUTOMATION_OU,
-    description: "Exclude Automation OU from SSO",
+  metadata: {
+    title: "Assign Google SAML Profile to Users/OUs",
+    description: "Turn on single sign-on for your users",
+    category: "SSO",
+    activity: "SSO",
+    provider: "Google",
+    automatability: "automated",
+    requires: [STEP_IDS.UPDATE_SAML_PROFILE],
   },
-
-  actions: ["POST /v1/inboundSamlSsoProfiles/{profile}:assignToOrgUnits"],
-  adminUrls: {
+  io: {
+    inputs: [
+      {
+        type: "keyValue",
+        data: {
+          key: OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME,
+          description: "Full name of the Google SAML profile",
+          producedBy: STEP_IDS.INITIATE_SAML_PROFILE,
+        },
+        stepTitle: "Initiate Google SAML Profile",
+      },
+    ],
+    outputs: [],
+  },
+  urls: {
     configure: portalUrls.google.sso.main(),
     verify: portalUrls.google.sso.main(),
   },
-  check: checkAssignSamlProfile,
-  execute: executeAssignSamlProfile,
-};
+  handlers: { check: checkAssignSamlProfile, execute: executeAssignSamlProfile },
+});

--- a/lib/steps/google/create-automation-ou/index.ts
+++ b/lib/steps/google/create-automation-ou/index.ts
@@ -1,59 +1,34 @@
-import type { StepDefinition, StepInput, StepOutput } from "@/lib/types";
-import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
+import { STEP_IDS } from "@/lib/steps/step-refs";
+import { defineStep } from "@/lib/steps/utils/step-factory";
+import { OUTPUT_KEYS } from "@/lib/types";
 import { checkAutomationOu } from "./check";
 import { executeCreateAutomationOu } from "./execute";
-import { STEP_IDS } from "@/lib/steps/step-refs";
 
-export const G1_OUTPUTS: StepOutput[] = [
-  {
-    key: OUTPUT_KEYS.AUTOMATION_OU_ID,
-    description: "Unique identifier for the organizational unit",
-  },
-  {
-    key: OUTPUT_KEYS.AUTOMATION_OU_PATH,
-    description: "Full path to the organizational unit",
-  },
-];
-
-export const G1_INPUTS: StepInput[] = [];
-
-export const g1CreateAutomationOu: StepDefinition = {
+export const g1CreateAutomationOu = defineStep({
   id: STEP_IDS.CREATE_AUTOMATION_OU,
-  title: "Create 'Automation' Organizational Unit",
-  description:
-    "Create a dedicated folder for automation users and service accounts",
-  details:
-    "Creates an organizational unit at the root level of your Google Workspace directory. This OU will contain service accounts and other automation-related users, keeping them separate from regular users for security and organization.",
-
-  category: "Google",
-  activity: "Foundation",
-  provider: "Google",
-
-  automatability: "automated",
-  automatable: true,
-
-  inputs: G1_INPUTS,
-  outputs: G1_OUTPUTS,
-  requires: [STEP_IDS.VERIFY_DOMAIN],
-  nextStep: {
-    id: STEP_IDS.CREATE_PROVISIONING_USER,
-    description: "Create a dedicated provisioning user in the Automation OU",
+  metadata: {
+    title: "Create 'Automation' Organizational Unit",
+    description: "Create a dedicated folder for automation users",
+    category: "Google",
+    activity: "Foundation",
+    provider: "Google",
+    automatability: "automated",
+    requires: [STEP_IDS.VERIFY_DOMAIN],
   },
-
-  actions: [
-    "OAuth 2.0 flow initiation",
-    "POST /admin/directory/v1/customer/{customerId}/orgunits",
-  ],
-  adminUrls: {
+  io: {
+    inputs: [],
+    outputs: [
+      { key: OUTPUT_KEYS.AUTOMATION_OU_ID, description: "Unique identifier for the organizational unit" },
+      { key: OUTPUT_KEYS.AUTOMATION_OU_PATH, description: "Full path to the organizational unit" },
+    ],
+  },
+  urls: {
     configure: portalUrls.google.orgUnits.list(),
     verify: (outputs) =>
       outputs[OUTPUT_KEYS.AUTOMATION_OU_PATH]
-        ? portalUrls.google.orgUnits.details(
-            outputs[OUTPUT_KEYS.AUTOMATION_OU_PATH] as string,
-          )
+        ? portalUrls.google.orgUnits.details(outputs[OUTPUT_KEYS.AUTOMATION_OU_PATH] as string)
         : portalUrls.google.orgUnits.list(),
   },
-  check: checkAutomationOu,
-  execute: executeCreateAutomationOu,
-};
+  handlers: { check: checkAutomationOu, execute: executeCreateAutomationOu },
+});

--- a/lib/steps/google/create-provisioning-user/index.ts
+++ b/lib/steps/google/create-provisioning-user/index.ts
@@ -1,70 +1,47 @@
-import type { StepDefinition, StepInput, StepOutput } from "@/lib/types";
-import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
+import { STEP_IDS } from "@/lib/steps/step-refs";
+import { defineStep } from "@/lib/steps/utils/step-factory";
+import { OUTPUT_KEYS } from "@/lib/types";
 import { checkProvisioningUser } from "./check";
 import { executeCreateProvisioningUser } from "./execute";
-import { STEP_IDS } from "@/lib/steps/step-refs";
 
-export const G2_OUTPUTS: StepOutput[] = [
-  {
-    key: OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL,
-    description: "Email address of the provisioning user",
-  },
-  {
-    key: OUTPUT_KEYS.SERVICE_ACCOUNT_ID,
-    description: "Unique identifier for the provisioning user",
-  },
-];
-
-export const G2_INPUTS: StepInput[] = [
-  {
-    type: "keyValue",
-    data: {
-      key: OUTPUT_KEYS.AUTOMATION_OU_PATH,
-      description: "Path to the Automation organizational unit",
-      producedBy: STEP_IDS.CREATE_AUTOMATION_OU,
-    },
-    stepTitle: "Create 'Automation' Organizational Unit",
-  },
-];
-
-export const g2CreateProvisioningUser: StepDefinition = {
+export const g2CreateProvisioningUser = defineStep({
   id: STEP_IDS.CREATE_PROVISIONING_USER,
-  title: "Create Provisioning User in 'Automation' OU",
-  description: "Create a sync user for Microsoft to connect with",
-  details:
-    "Creates a service account user (azuread-provisioning@domain) within the Automation OU. This account will be used by Azure AD to authenticate and sync users to Google Workspace via OAuth.",
-
-  category: "Google",
-  activity: "Foundation",
-  provider: "Google",
-
-  automatability: "automated",
-  automatable: true,
-
-  inputs: G2_INPUTS,
-  outputs: G2_OUTPUTS,
-  requires: [STEP_IDS.CREATE_AUTOMATION_OU],
-  nextStep: {
-    id: STEP_IDS.GRANT_SUPER_ADMIN,
-    description: "Grant admin privileges to the provisioning user",
+  metadata: {
+    title: "Create Provisioning User in 'Automation' OU",
+    description: "Create a sync user for Microsoft to connect with",
+    category: "Google",
+    activity: "Foundation",
+    provider: "Google",
+    automatability: "automated",
+    requires: [STEP_IDS.CREATE_AUTOMATION_OU],
   },
-
-  actions: ["POST /admin/directory/v1/users"],
-  adminUrls: {
+  io: {
+    inputs: [
+      {
+        type: "keyValue",
+        data: {
+          key: OUTPUT_KEYS.AUTOMATION_OU_PATH,
+          description: "Path to the Automation organizational unit",
+          producedBy: STEP_IDS.CREATE_AUTOMATION_OU,
+        },
+        stepTitle: "Create 'Automation' Organizational Unit",
+      },
+    ],
+    outputs: [
+      { key: OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL, description: "Email address of the provisioning user" },
+      { key: OUTPUT_KEYS.SERVICE_ACCOUNT_ID, description: "Unique identifier for the provisioning user" },
+    ],
+  },
+  urls: {
     configure: (outputs) =>
       outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL]
-        ? portalUrls.google.users.details(
-            outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL] as string,
-          )
+        ? portalUrls.google.users.details(outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL] as string)
         : portalUrls.google.users.list(),
     verify: (outputs) =>
       outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL]
-        ? portalUrls.google.users.details(
-            outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL] as string,
-          )
+        ? portalUrls.google.users.details(outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL] as string)
         : portalUrls.google.users.list(),
   },
-  check: checkProvisioningUser,
-  execute: executeCreateProvisioningUser,
-};
+  handlers: { check: checkProvisioningUser, execute: executeCreateProvisioningUser },
+});

--- a/lib/steps/google/exclude-automation-ou/index.ts
+++ b/lib/steps/google/exclude-automation-ou/index.ts
@@ -1,46 +1,38 @@
-import type { StepDefinition, StepInput, StepOutput } from "@/lib/types";
-import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
+import { STEP_IDS } from "@/lib/steps/step-refs";
+import { defineStep } from "@/lib/steps/utils/step-factory";
+import { OUTPUT_KEYS } from "@/lib/types";
 import { checkExcludeAutomationOu } from "./check";
 import { executeExcludeAutomationOu } from "./execute";
-import { STEP_IDS } from "@/lib/steps/step-refs";
 
-export const G8_OUTPUTS: StepOutput[] = [];
-export const G8_INPUTS: StepInput[] = [
-  {
-    type: "keyValue",
-    data: {
-      key: OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME,
-      description: "Full name of the Google SAML profile",
-      producedBy: STEP_IDS.INITIATE_SAML_PROFILE,
-    },
-    stepTitle: "Initiate Google SAML Profile",
-  },
-];
-
-export const g8ExcludeAutomationOu: StepDefinition = {
+export const g8ExcludeAutomationOu = defineStep({
   id: STEP_IDS.EXCLUDE_AUTOMATION_OU,
-  title: "Exclude Automation OU from SSO (Optional)",
-  description: "Keep sync user using Google sign-in (optional)",
-  details:
-    "Optionally excludes the Automation organizational unit from the assigned SAML profile so service accounts continue to use Google sign-in instead of SSO.",
-
-  category: "SSO",
-  activity: "SSO",
-  provider: "Google",
-
-  automatability: "supervised",
-  automatable: true,
-  inputs: G8_INPUTS,
-  outputs: G8_OUTPUTS,
-  requires: [STEP_IDS.ASSIGN_SAML_PROFILE],
-  nextStep: undefined,
-
-  actions: ["PATCH /v1/inboundSamlSsoProfiles/{profile}:unassignFromOrgUnits"],
-  adminUrls: {
+  metadata: {
+    title: "Exclude Automation OU from SSO (Optional)",
+    description: "Keep sync user using Google sign-in (optional)",
+    category: "SSO",
+    activity: "SSO",
+    provider: "Google",
+    automatability: "supervised",
+    requires: [STEP_IDS.ASSIGN_SAML_PROFILE],
+  },
+  io: {
+    inputs: [
+      {
+        type: "keyValue",
+        data: {
+          key: OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME,
+          description: "Full name of the Google SAML profile",
+          producedBy: STEP_IDS.INITIATE_SAML_PROFILE,
+        },
+        stepTitle: "Initiate Google SAML Profile",
+      },
+    ],
+    outputs: [],
+  },
+  urls: {
     configure: portalUrls.google.sso.main(),
     verify: portalUrls.google.sso.main(),
   },
-  check: checkExcludeAutomationOu,
-  execute: executeExcludeAutomationOu,
-};
+  handlers: { check: checkExcludeAutomationOu, execute: executeExcludeAutomationOu },
+});

--- a/lib/steps/google/grant-super-admin/index.ts
+++ b/lib/steps/google/grant-super-admin/index.ts
@@ -1,66 +1,46 @@
-import type { StepDefinition, StepInput, StepOutput } from "@/lib/types";
-import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
+import { STEP_IDS } from "@/lib/steps/step-refs";
+import { defineStep } from "@/lib/steps/utils/step-factory";
+import { OUTPUT_KEYS } from "@/lib/types";
 import { checkSuperAdmin } from "./check";
 import { executeGrantSuperAdmin } from "./execute";
-import { STEP_IDS } from "@/lib/steps/step-refs";
 
-export const G3_OUTPUTS: StepOutput[] = [
-  {
-    key: OUTPUT_KEYS.SUPER_ADMIN_ROLE_ID,
-    description: "Role assignment ID for Super Admin",
-  },
-];
-
-export const G3_INPUTS: StepInput[] = [
-  {
-    type: "keyValue",
-    data: {
-      key: OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL,
-      description: "Email of the provisioning user",
-      producedBy: STEP_IDS.CREATE_PROVISIONING_USER,
-    },
-    stepTitle: "Create Provisioning User",
-  },
-];
-
-export const g3GrantSuperAdmin: StepDefinition = {
+export const g3GrantSuperAdmin = defineStep({
   id: STEP_IDS.GRANT_SUPER_ADMIN,
-  title: "Grant Super Admin Privileges to Provisioning User",
-  description: "Give the sync user admin permissions",
-  details:
-    "Assigns Super Admin role to the provisioning user, granting full access to manage users, groups, and organizational units. This is required for Azure AD to perform provisioning operations.",
-
-  category: "Google",
-  activity: "Foundation",
-  provider: "Google",
-
-  automatability: "automated",
-  automatable: true,
-
-  inputs: G3_INPUTS,
-  outputs: G3_OUTPUTS,
-  requires: [STEP_IDS.CREATE_PROVISIONING_USER, STEP_IDS.VERIFY_DOMAIN],
-  nextStep: {
-    id: STEP_IDS.VERIFY_DOMAIN,
-    description: "Verify your domain for federation",
+  metadata: {
+    title: "Grant Super Admin Privileges to Provisioning User",
+    description: "Give the sync user admin permissions",
+    category: "Google",
+    activity: "Foundation",
+    provider: "Google",
+    automatability: "automated",
+    requires: [STEP_IDS.CREATE_PROVISIONING_USER, STEP_IDS.VERIFY_DOMAIN],
   },
-
-  actions: ["POST /admin/directory/v1/customer/{customerId}/roleassignments"],
-  adminUrls: {
+  io: {
+    inputs: [
+      {
+        type: "keyValue",
+        data: {
+          key: OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL,
+          description: "Email of the provisioning user",
+          producedBy: STEP_IDS.CREATE_PROVISIONING_USER,
+        },
+        stepTitle: "Create Provisioning User",
+      },
+    ],
+    outputs: [
+      { key: OUTPUT_KEYS.SUPER_ADMIN_ROLE_ID, description: "Role assignment ID for Super Admin" },
+    ],
+  },
+  urls: {
     configure: (outputs) =>
       outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL]
-        ? portalUrls.google.users.details(
-            outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL] as string,
-          )
+        ? portalUrls.google.users.details(outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL] as string)
         : portalUrls.google.users.list(),
     verify: (outputs) =>
       outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL]
-        ? portalUrls.google.users.details(
-            outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL] as string,
-          )
+        ? portalUrls.google.users.details(outputs[OUTPUT_KEYS.SERVICE_ACCOUNT_EMAIL] as string)
         : portalUrls.google.users.list(),
   },
-  check: checkSuperAdmin,
-  execute: executeGrantSuperAdmin,
-};
+  handlers: { check: checkSuperAdmin, execute: executeGrantSuperAdmin },
+});

--- a/lib/steps/google/initiate-saml-profile/index.ts
+++ b/lib/steps/google/initiate-saml-profile/index.ts
@@ -1,54 +1,33 @@
 import { portalUrls } from "@/lib/api/url-builder";
 import { STEP_IDS } from "@/lib/steps/step-refs";
-import type { StepDefinition, StepInput, StepOutput } from "@/lib/types";
+import { defineStep } from "@/lib/steps/utils/step-factory";
 import { OUTPUT_KEYS } from "@/lib/types";
 import { checkSamlProfile } from "./check";
 import { executeInitiateSamlProfile } from "./execute";
 
-export const G5_OUTPUTS: StepOutput[] = [
-  {
-    key: OUTPUT_KEYS.GOOGLE_SAML_PROFILE_NAME,
-    description: "SAML profile name",
-  },
-  {
-    key: OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME,
-    description: "Full resource name of the SAML profile",
-  },
-  {
-    key: OUTPUT_KEYS.GOOGLE_SAML_SP_ENTITY_ID,
-    description: "Google SP Entity ID",
-  },
-  { key: OUTPUT_KEYS.GOOGLE_SAML_SP_ACS_URL, description: "Google ACS URL" },
-];
-
-export const G5_INPUTS: StepInput[] = [];
-
-export const g5InitiateSamlProfile: StepDefinition = {
+export const g5InitiateSamlProfile = defineStep({
   id: STEP_IDS.INITIATE_SAML_PROFILE,
-  title: "Initiate Google SAML Profile & Get SP Details",
-  description: "Set up single sign-on profile and get connection details",
-  details:
-    "Creates a new SAML SSO profile in Google Workspace and captures the Service Provider (SP) entity ID and ACS URL used by Microsoft Entra ID.",
-
-  category: "Google",
-  activity: "SSO",
-  provider: "Google",
-
-  automatability: "automated",
-  automatable: true,
-  inputs: G5_INPUTS,
-  outputs: G5_OUTPUTS,
-  requires: [STEP_IDS.VERIFY_DOMAIN],
-  nextStep: {
-    id: STEP_IDS.UPDATE_SAML_PROFILE,
-    description: "Update the SAML profile with IdP info",
+  metadata: {
+    title: "Initiate Google SAML Profile & Get SP Details",
+    description: "Set up single sign-on profile and get connection details",
+    category: "Google",
+    activity: "SSO",
+    provider: "Google",
+    automatability: "automated",
+    requires: [STEP_IDS.VERIFY_DOMAIN],
   },
-
-  actions: ["POST /v1/inboundSamlSsoProfiles"],
-  adminUrls: {
+  io: {
+    inputs: [],
+    outputs: [
+      { key: OUTPUT_KEYS.GOOGLE_SAML_PROFILE_NAME, description: "SAML profile name" },
+      { key: OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME, description: "Full resource name of the SAML profile" },
+      { key: OUTPUT_KEYS.GOOGLE_SAML_SP_ENTITY_ID, description: "Google SP Entity ID" },
+      { key: OUTPUT_KEYS.GOOGLE_SAML_SP_ACS_URL, description: "Google ACS URL" },
+    ],
+  },
+  urls: {
     configure: portalUrls.google.sso.main(),
     verify: portalUrls.google.sso.main(),
   },
-  check: checkSamlProfile,
-  execute: executeInitiateSamlProfile,
-};
+  handlers: { check: checkSamlProfile, execute: executeInitiateSamlProfile },
+});

--- a/lib/steps/google/update-saml-profile/index.ts
+++ b/lib/steps/google/update-saml-profile/index.ts
@@ -1,76 +1,65 @@
-import type { StepDefinition, StepInput, StepOutput } from "@/lib/types";
-import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
+import { STEP_IDS } from "@/lib/steps/step-refs";
+import { defineStep } from "@/lib/steps/utils/step-factory";
+import { OUTPUT_KEYS } from "@/lib/types";
 import { checkSamlProfileUpdate } from "./check";
 import { executeUpdateSamlProfile } from "./execute";
-import { STEP_IDS } from "@/lib/steps/step-refs";
 
-export const G6_OUTPUTS: StepOutput[] = [];
-export const G6_INPUTS: StepInput[] = [
-  {
-    type: "keyValue",
-    data: {
-      key: OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME,
-      description: "Full name of the Google SAML profile",
-      producedBy: STEP_IDS.INITIATE_SAML_PROFILE,
-    },
-    stepTitle: "Initiate Google SAML Profile",
-  },
-  {
-    type: "keyValue",
-    data: {
-      key: OUTPUT_KEYS.IDP_ENTITY_ID,
-      description: "Azure AD Entity ID",
-      producedBy: STEP_IDS.RETRIEVE_IDP_METADATA,
-    },
-    stepTitle: "Retrieve Azure AD IdP Metadata",
-  },
-  {
-    type: "keyValue",
-    data: {
-      key: OUTPUT_KEYS.IDP_SSO_URL,
-      description: "Azure AD SSO URL",
-      producedBy: STEP_IDS.RETRIEVE_IDP_METADATA,
-    },
-    stepTitle: "Retrieve Azure AD IdP Metadata",
-  },
-  {
-    type: "keyValue",
-    data: {
-      key: OUTPUT_KEYS.IDP_CERTIFICATE_BASE64,
-      description: "Azure AD signing certificate",
-      producedBy: STEP_IDS.RETRIEVE_IDP_METADATA,
-    },
-    stepTitle: "Retrieve Azure AD IdP Metadata",
-  },
-];
-
-export const g6UpdateSamlProfile: StepDefinition = {
+export const g6UpdateSamlProfile = defineStep({
   id: STEP_IDS.UPDATE_SAML_PROFILE,
-  title: "Update Google SAML Profile with Azure AD IdP Info",
-  description: "Connect Google to Microsoft using sign-on details",
-  details:
-    "Updates the Google SAML profile with metadata from Azure AD including entity ID, SSO URL, and certificate. This completes the trust relationship for SSO.",
-
-  category: "SSO",
-  activity: "SSO",
-  provider: "Google",
-
-  automatability: "automated",
-  automatable: true,
-  inputs: G6_INPUTS,
-  outputs: G6_OUTPUTS,
-  requires: [STEP_IDS.INITIATE_SAML_PROFILE, STEP_IDS.RETRIEVE_IDP_METADATA],
-  nextStep: {
-    id: STEP_IDS.ASSIGN_SAML_PROFILE,
-    description: "Assign the SAML profile",
+  metadata: {
+    title: "Update Google SAML Profile with Azure AD IdP Info",
+    description: "Connect Google to Microsoft using sign-on details",
+    category: "SSO",
+    activity: "SSO",
+    provider: "Google",
+    automatability: "automated",
+    requires: [STEP_IDS.INITIATE_SAML_PROFILE, STEP_IDS.RETRIEVE_IDP_METADATA],
   },
-
-  actions: ["PATCH /v1/inboundSamlSsoProfiles/{profile}"],
-  adminUrls: {
+  io: {
+    inputs: [
+      {
+        type: "keyValue",
+        data: {
+          key: OUTPUT_KEYS.GOOGLE_SAML_PROFILE_FULL_NAME,
+          description: "Full name of the Google SAML profile",
+          producedBy: STEP_IDS.INITIATE_SAML_PROFILE,
+        },
+        stepTitle: "Initiate Google SAML Profile",
+      },
+      {
+        type: "keyValue",
+        data: {
+          key: OUTPUT_KEYS.IDP_ENTITY_ID,
+          description: "Azure AD Entity ID",
+          producedBy: STEP_IDS.RETRIEVE_IDP_METADATA,
+        },
+        stepTitle: "Retrieve Azure AD IdP Metadata",
+      },
+      {
+        type: "keyValue",
+        data: {
+          key: OUTPUT_KEYS.IDP_SSO_URL,
+          description: "Azure AD SSO URL",
+          producedBy: STEP_IDS.RETRIEVE_IDP_METADATA,
+        },
+        stepTitle: "Retrieve Azure AD IdP Metadata",
+      },
+      {
+        type: "keyValue",
+        data: {
+          key: OUTPUT_KEYS.IDP_CERTIFICATE_BASE64,
+          description: "Azure AD signing certificate",
+          producedBy: STEP_IDS.RETRIEVE_IDP_METADATA,
+        },
+        stepTitle: "Retrieve Azure AD IdP Metadata",
+      },
+    ],
+    outputs: [],
+  },
+  urls: {
     configure: portalUrls.google.sso.main(),
     verify: portalUrls.google.sso.main(),
   },
-  check: checkSamlProfileUpdate,
-  execute: executeUpdateSamlProfile,
-};
+  handlers: { check: checkSamlProfileUpdate, execute: executeUpdateSamlProfile },
+});

--- a/lib/steps/google/verify-domain/index.ts
+++ b/lib/steps/google/verify-domain/index.ts
@@ -1,39 +1,26 @@
 import { portalUrls } from "@/lib/api/url-builder";
 import { STEP_IDS } from "@/lib/steps/step-refs";
-import type { StepDefinition, StepInput, StepOutput } from "@/lib/types";
+import { defineStep } from "@/lib/steps/utils/step-factory";
 import { checkDomain } from "./check";
 import { executeVerifyDomain } from "./execute";
 
-export const G4_OUTPUTS: StepOutput[] = [];
-export const G4_INPUTS: StepInput[] = [];
-
-export const g4VerifyDomain: StepDefinition = {
+export const g4VerifyDomain = defineStep({
   id: STEP_IDS.VERIFY_DOMAIN,
-  title: "Add & Verify Domain for Federation",
-  description: "Verify your domain is ready for single sign-on",
-  details:
-    "Adds your primary domain to Google Workspace and verifies ownership via DNS. This step ensures that federation and provisioning operate on a verified domain.",
-
-  category: "Google",
-  activity: "Foundation",
-  provider: "Google",
-
-  automatability: "supervised",
-  automatable: true,
-
-  inputs: G4_INPUTS,
-  outputs: G4_OUTPUTS,
-  requires: [],
-  nextStep: {
-    id: STEP_IDS.INITIATE_SAML_PROFILE,
-    description: "Create the SAML SSO profile",
+  metadata: {
+    title: "Add & Verify Domain for Federation",
+    description: "Verify your domain is ready for single sign-on",
+    category: "Google",
+    activity: "Foundation",
+    provider: "Google",
+    automatability: "supervised",
   },
-
-  actions: ["POST /admin/directory/v1/customer/{customerId}/domains"],
-  adminUrls: {
+  io: {
+    inputs: [],
+    outputs: [],
+  },
+  urls: {
     configure: portalUrls.google.domains.manage(),
     verify: portalUrls.google.domains.manage(),
   },
-  check: checkDomain,
-  execute: executeVerifyDomain,
-};
+  handlers: { check: checkDomain, execute: executeVerifyDomain },
+});

--- a/lib/steps/microsoft/assign-users-sso/index.ts
+++ b/lib/steps/microsoft/assign-users-sso/index.ts
@@ -1,72 +1,57 @@
-import type { StepDefinition, StepInput, StepOutput } from "@/lib/types";
-import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
+import { STEP_IDS } from "@/lib/steps/step-refs";
+import { defineStep } from "@/lib/steps/utils/step-factory";
+import { OUTPUT_KEYS } from "@/lib/types";
 import { checkAssignUsers } from "./check";
 import { executeAssignUsers } from "./execute";
-import { STEP_IDS } from "@/lib/steps/step-refs";
 
-export const M9_OUTPUTS: StepOutput[] = [];
-
-export const M9_INPUTS: StepInput[] = [
-  {
-    type: "keyValue",
-    data: {
-      key: OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID,
-      description: "SSO service principal ID",
-      producedBy: STEP_IDS.CREATE_SAML_APP,
-    },
-    stepTitle: "Create SAML App",
-  },
-  {
-    type: "keyValue",
-    data: {
-      key: OUTPUT_KEYS.SAML_SSO_APP_ID,
-      description: "SSO app ID",
-      producedBy: STEP_IDS.CREATE_SAML_APP,
-    },
-    stepTitle: "Create SAML App",
-  },
-];
-
-export const m9AssignUsersSso: StepDefinition = {
+export const m9AssignUsersSso = defineStep({
   id: STEP_IDS.ASSIGN_USERS_SSO,
-  title: "Assign Users/Groups to Azure AD SSO App",
-  description: "Choose who can use single sign-on",
-  details:
-    "Assigns users or groups to the SSO application so they can authenticate via Azure AD. Only assigned users will be able to sign in to Google Workspace using SSO.",
-
-  category: "Microsoft",
-  activity: "SSO",
-  provider: "Microsoft",
-
-  automatability: "manual",
-  automatable: true,
-
-  inputs: M9_INPUTS,
-  outputs: M9_OUTPUTS,
-  requires: [STEP_IDS.CREATE_SAML_APP],
-  nextStep: { id: STEP_IDS.TEST_SSO, description: "Test sign-in" },
-  actions: ["Manual: Add user or group assignments"],
-  adminUrls: {
+  metadata: {
+    title: "Assign Users/Groups to Azure AD SSO App",
+    description: "Choose who can use single sign-on",
+    category: "Microsoft",
+    activity: "SSO",
+    provider: "Microsoft",
+    automatability: "manual",
+    requires: [STEP_IDS.CREATE_SAML_APP],
+  },
+  io: {
+    inputs: [
+      {
+        type: "keyValue",
+        data: {
+          key: OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID,
+          description: "SSO service principal ID",
+          producedBy: STEP_IDS.CREATE_SAML_APP,
+        },
+        stepTitle: "Create SAML App",
+      },
+      {
+        type: "keyValue",
+        data: {
+          key: OUTPUT_KEYS.SAML_SSO_APP_ID,
+          description: "SSO app ID",
+          producedBy: STEP_IDS.CREATE_SAML_APP,
+        },
+        stepTitle: "Create SAML App",
+      },
+    ],
+    outputs: [],
+  },
+  urls: {
     configure: (outputs) => {
       const spId = outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.SAML_SSO_APP_ID];
       if (!spId || !appId) return null;
-      return portalUrls.azure.enterpriseApp.usersAndGroups(
-        spId as string,
-        appId as string,
-      );
+      return portalUrls.azure.enterpriseApp.usersAndGroups(spId as string, appId as string);
     },
     verify: (outputs) => {
       const spId = outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.SAML_SSO_APP_ID];
       if (!spId || !appId) return null;
-      return portalUrls.azure.enterpriseApp.usersAndGroups(
-        spId as string,
-        appId as string,
-      );
+      return portalUrls.azure.enterpriseApp.usersAndGroups(spId as string, appId as string);
     },
   },
-  check: checkAssignUsers,
-  execute: executeAssignUsers,
-};
+  handlers: { check: checkAssignUsers, execute: executeAssignUsers },
+});

--- a/lib/steps/microsoft/authorize-provisioning/index.ts
+++ b/lib/steps/microsoft/authorize-provisioning/index.ts
@@ -1,78 +1,51 @@
-import type { StepDefinition, StepInput, StepOutput } from "@/lib/types";
-import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
+import { STEP_IDS } from "@/lib/steps/step-refs";
+import { defineStep } from "@/lib/steps/utils/step-factory";
+import { OUTPUT_KEYS } from "@/lib/types";
 import { checkAuthorizeProvisioning } from "./check";
 import { executeAuthorizeProvisioning } from "./execute";
-import { STEP_IDS } from "@/lib/steps/step-refs";
 
-export const M3_OUTPUTS: StepOutput[] = [
-  {
-    key: OUTPUT_KEYS.FLAG_M3_PROV_CREDS_CONFIGURED,
-    description: "Provisioning connection authorized",
-  },
-  { key: OUTPUT_KEYS.PROVISIONING_JOB_ID, description: "Provisioning job ID" },
-];
-
-export const M3_INPUTS: StepInput[] = [
-  {
-    type: "keyValue",
-    data: {
-      key: OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID,
-      description: "Service principal object ID",
-      producedBy: STEP_IDS.CREATE_PROVISIONING_APP,
-    },
-    stepTitle: "Create Provisioning App",
-  },
-];
-
-export const m3AuthorizeProvisioning: StepDefinition = {
+export const m3AuthorizeProvisioning = defineStep({
   id: STEP_IDS.AUTHORIZE_PROVISIONING,
-  title: "Authorize Azure AD Provisioning to Google Workspace",
-  description:
-    "Connect Microsoft to Google: Click 'Authorize' in Azure and sign in with the Google sync user",
-  details:
-    "Manually complete the OAuth consent flow in the Azure portal using the provisioning user. This grants Azure AD permission to manage users and groups in Google Workspace.",
-
-  category: "Microsoft",
-  activity: "Provisioning",
-  provider: "Microsoft",
-
-  automatability: "manual",
-  automatable: false,
-  inputs: M3_INPUTS,
-  outputs: M3_OUTPUTS,
-  requires: [STEP_IDS.ENABLE_PROVISIONING_SP, STEP_IDS.GRANT_SUPER_ADMIN],
-  nextStep: {
-    id: STEP_IDS.CONFIGURE_ATTRIBUTE_MAPPINGS,
-    description: "Configure how user attributes map between systems",
+  metadata: {
+    title: "Authorize Azure AD Provisioning to Google Workspace",
+    description: "Connect Microsoft to Google: Click 'Authorize' in Azure and sign in with the Google sync user",
+    category: "Microsoft",
+    activity: "Provisioning",
+    provider: "Microsoft",
+    automatability: "manual",
+    requires: [STEP_IDS.ENABLE_PROVISIONING_SP, STEP_IDS.GRANT_SUPER_ADMIN],
   },
-
-  actions: [
-    "Manual: Click 'Authorize' in Azure portal",
-    "Manual: Sign in with provisioning user",
-    "Manual: Grant consent",
-    "Manual: Test connection",
-  ],
-  adminUrls: {
+  io: {
+    inputs: [
+      {
+        type: "keyValue",
+        data: {
+          key: OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID,
+          description: "Service principal object ID",
+          producedBy: STEP_IDS.CREATE_PROVISIONING_APP,
+        },
+        stepTitle: "Create Provisioning App",
+      },
+    ],
+    outputs: [
+      { key: OUTPUT_KEYS.FLAG_M3_PROV_CREDS_CONFIGURED, description: "Provisioning connection authorized" },
+      { key: OUTPUT_KEYS.PROVISIONING_JOB_ID, description: "Provisioning job ID" },
+    ],
+  },
+  urls: {
     configure: (outputs) => {
       const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
       if (!spId || !appId) return null;
-      return portalUrls.azure.enterpriseApp.provisioning(
-        spId as string,
-        appId as string,
-      );
+      return portalUrls.azure.enterpriseApp.provisioning(spId as string, appId as string);
     },
     verify: (outputs) => {
       const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
       if (!spId || !appId) return null;
-      return portalUrls.azure.enterpriseApp.provisioning(
-        spId as string,
-        appId as string,
-      );
+      return portalUrls.azure.enterpriseApp.provisioning(spId as string, appId as string);
     },
   },
-  check: checkAuthorizeProvisioning,
-  execute: executeAuthorizeProvisioning,
-};
+  handlers: { check: checkAuthorizeProvisioning, execute: executeAuthorizeProvisioning },
+});

--- a/lib/steps/microsoft/configure-attribute-mappings/index.ts
+++ b/lib/steps/microsoft/configure-attribute-mappings/index.ts
@@ -1,88 +1,68 @@
-import type { StepDefinition, StepInput, StepOutput } from "@/lib/types";
-import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
+import { STEP_IDS } from "@/lib/steps/step-refs";
+import { defineStep } from "@/lib/steps/utils/step-factory";
+import { OUTPUT_KEYS } from "@/lib/types";
 import { checkAttributeMappings } from "./check";
 import { executeConfigureAttributeMappings } from "./execute";
-import { STEP_IDS } from "@/lib/steps/step-refs";
 
-export const M4_OUTPUTS: StepOutput[] = [
-  {
-    key: OUTPUT_KEYS.FLAG_M4_PROV_MAPPINGS_CONFIGURED,
-    description: "Attribute mappings configured",
-  },
-];
-
-export const M4_INPUTS: StepInput[] = [
-  {
-    type: "keyValue",
-    data: {
-      key: OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID,
-      description: "Service principal object ID",
-      producedBy: STEP_IDS.CREATE_PROVISIONING_APP,
-    },
-    stepTitle: "Create Provisioning App",
-  },
-  {
-    type: "keyValue",
-    data: {
-      key: OUTPUT_KEYS.PROVISIONING_JOB_ID,
-      description: "Provisioning job ID",
-      producedBy: STEP_IDS.AUTHORIZE_PROVISIONING,
-    },
-    stepTitle: "Authorize Provisioning",
-  },
-  {
-    type: "keyValue",
-    data: {
-      key: OUTPUT_KEYS.PROVISIONING_APP_ID,
-      description: "Provisioning app ID",
-      producedBy: STEP_IDS.CREATE_PROVISIONING_APP,
-    },
-    stepTitle: "Create Provisioning App",
-  },
-];
-
-export const m4ConfigureAttributeMappings: StepDefinition = {
+export const m4ConfigureAttributeMappings = defineStep({
   id: STEP_IDS.CONFIGURE_ATTRIBUTE_MAPPINGS,
-  title: "Configure Attribute Mappings (Provisioning)",
-  description: "Set up how user data syncs between systems",
-  details:
-    "Defines how Azure AD attributes map to Google Workspace fields. Proper mappings ensure user information like names and group membership sync correctly.",
-
-  category: "Microsoft",
-  activity: "Provisioning",
-  provider: "Microsoft",
-
-  automatability: "manual",
-  automatable: true,
-  inputs: M4_INPUTS,
-  outputs: M4_OUTPUTS,
-  requires: [STEP_IDS.AUTHORIZE_PROVISIONING],
-  nextStep: {
-    id: STEP_IDS.START_PROVISIONING,
-    description: "Start synchronization job",
+  metadata: {
+    title: "Configure Attribute Mappings (Provisioning)",
+    description: "Set up how user data syncs between systems",
+    category: "Microsoft",
+    activity: "Provisioning",
+    provider: "Microsoft",
+    automatability: "manual",
+    requires: [STEP_IDS.AUTHORIZE_PROVISIONING],
   },
-  actions: ["Manual: Edit attribute mappings in portal"],
-  adminUrls: {
+  io: {
+    inputs: [
+      {
+        type: "keyValue",
+        data: {
+          key: OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID,
+          description: "Service principal object ID",
+          producedBy: STEP_IDS.CREATE_PROVISIONING_APP,
+        },
+        stepTitle: "Create Provisioning App",
+      },
+      {
+        type: "keyValue",
+        data: {
+          key: OUTPUT_KEYS.PROVISIONING_JOB_ID,
+          description: "Provisioning job ID",
+          producedBy: STEP_IDS.AUTHORIZE_PROVISIONING,
+        },
+        stepTitle: "Authorize Provisioning",
+      },
+      {
+        type: "keyValue",
+        data: {
+          key: OUTPUT_KEYS.PROVISIONING_APP_ID,
+          description: "Provisioning app ID",
+          producedBy: STEP_IDS.CREATE_PROVISIONING_APP,
+        },
+        stepTitle: "Create Provisioning App",
+      },
+    ],
+    outputs: [
+      { key: OUTPUT_KEYS.FLAG_M4_PROV_MAPPINGS_CONFIGURED, description: "Attribute mappings configured" },
+    ],
+  },
+  urls: {
     configure: (outputs) => {
       const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
       if (!spId || !appId) return null;
-      return portalUrls.azure.enterpriseApp.provisioning(
-        spId as string,
-        appId as string,
-      );
+      return portalUrls.azure.enterpriseApp.provisioning(spId as string, appId as string);
     },
     verify: (outputs) => {
       const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
       if (!spId || !appId) return null;
-      return portalUrls.azure.enterpriseApp.provisioning(
-        spId as string,
-        appId as string,
-      );
+      return portalUrls.azure.enterpriseApp.provisioning(spId as string, appId as string);
     },
   },
-  check: checkAttributeMappings,
-  execute: executeConfigureAttributeMappings,
-};
+  handlers: { check: checkAttributeMappings, execute: executeConfigureAttributeMappings },
+});

--- a/lib/steps/microsoft/configure-saml-app/index.ts
+++ b/lib/steps/microsoft/configure-saml-app/index.ts
@@ -1,107 +1,86 @@
-import type { StepDefinition, StepInput, StepOutput } from "@/lib/types";
-import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
+import { STEP_IDS } from "@/lib/steps/step-refs";
+import { defineStep } from "@/lib/steps/utils/step-factory";
+import { OUTPUT_KEYS } from "@/lib/types";
 import { checkConfigureSamlApp } from "./check";
 import { executeConfigureSamlApp } from "./execute";
-import { STEP_IDS } from "@/lib/steps/step-refs";
 
-export const M7_OUTPUTS: StepOutput[] = [
-  {
-    key: OUTPUT_KEYS.FLAG_M7_SAML_APP_SETTINGS_CONFIGURED,
-    description: "SAML app settings configured",
-  },
-];
-
-export const M7_INPUTS: StepInput[] = [
-  {
-    type: "keyValue",
-    data: {
-      key: OUTPUT_KEYS.SAML_SSO_APP_OBJECT_ID,
-      description: "Application Object ID",
-      producedBy: STEP_IDS.CREATE_SAML_APP,
-    },
-    stepTitle: "Create SAML App",
-  },
-  {
-    type: "keyValue",
-    data: {
-      key: OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID,
-      description: "Service principal ID",
-      producedBy: STEP_IDS.CREATE_SAML_APP,
-    },
-    stepTitle: "Create SAML App",
-  },
-  {
-    type: "keyValue",
-    data: {
-      key: OUTPUT_KEYS.SAML_SSO_APP_ID,
-      description: "App (Client) ID",
-      producedBy: STEP_IDS.CREATE_SAML_APP,
-    },
-    stepTitle: "Create SAML App",
-  },
-  {
-    type: "keyValue",
-    data: {
-      key: OUTPUT_KEYS.GOOGLE_SAML_SP_ENTITY_ID,
-      description: "Google SP Entity ID",
-      producedBy: STEP_IDS.INITIATE_SAML_PROFILE,
-    },
-    stepTitle: "Initiate Google SAML Profile",
-  },
-  {
-    type: "keyValue",
-    data: {
-      key: OUTPUT_KEYS.GOOGLE_SAML_SP_ACS_URL,
-      description: "Google ACS URL",
-      producedBy: STEP_IDS.INITIATE_SAML_PROFILE,
-    },
-    stepTitle: "Initiate Google SAML Profile",
-  },
-];
-
-export const m7ConfigureSamlApp: StepDefinition = {
+export const m7ConfigureSamlApp = defineStep({
   id: STEP_IDS.CONFIGURE_SAML_APP,
-  title: "Configure Azure AD SAML App for Google",
-  description: "Configure single sign-on settings with Google's details",
-  details:
-    "Updates the SAML application with Google's ACS URL and entity ID and uploads the Azure AD signing certificate. This finalizes the SAML setup in Microsoft Entra ID.",
-
-  category: "Microsoft",
-  activity: "SSO",
-  provider: "Microsoft",
-
-  automatability: "manual",
-  automatable: true,
-
-  inputs: M7_INPUTS,
-  outputs: M7_OUTPUTS,
-  requires: [STEP_IDS.CREATE_SAML_APP, STEP_IDS.INITIATE_SAML_PROFILE],
-  nextStep: {
-    id: STEP_IDS.RETRIEVE_IDP_METADATA,
-    description: "Retrieve IdP metadata",
+  metadata: {
+    title: "Configure Azure AD SAML App for Google",
+    description: "Configure single sign-on settings with Google's details",
+    category: "Microsoft",
+    activity: "SSO",
+    provider: "Microsoft",
+    automatability: "manual",
+    requires: [STEP_IDS.CREATE_SAML_APP, STEP_IDS.INITIATE_SAML_PROFILE],
   },
-  actions: ["Manual: Enter SAML settings in portal"],
-  adminUrls: {
+  io: {
+    inputs: [
+      {
+        type: "keyValue",
+        data: {
+          key: OUTPUT_KEYS.SAML_SSO_APP_OBJECT_ID,
+          description: "Application Object ID",
+          producedBy: STEP_IDS.CREATE_SAML_APP,
+        },
+        stepTitle: "Create SAML App",
+      },
+      {
+        type: "keyValue",
+        data: {
+          key: OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID,
+          description: "Service principal ID",
+          producedBy: STEP_IDS.CREATE_SAML_APP,
+        },
+        stepTitle: "Create SAML App",
+      },
+      {
+        type: "keyValue",
+        data: {
+          key: OUTPUT_KEYS.SAML_SSO_APP_ID,
+          description: "App (Client) ID",
+          producedBy: STEP_IDS.CREATE_SAML_APP,
+        },
+        stepTitle: "Create SAML App",
+      },
+      {
+        type: "keyValue",
+        data: {
+          key: OUTPUT_KEYS.GOOGLE_SAML_SP_ENTITY_ID,
+          description: "Google SP Entity ID",
+          producedBy: STEP_IDS.INITIATE_SAML_PROFILE,
+        },
+        stepTitle: "Initiate Google SAML Profile",
+      },
+      {
+        type: "keyValue",
+        data: {
+          key: OUTPUT_KEYS.GOOGLE_SAML_SP_ACS_URL,
+          description: "Google ACS URL",
+          producedBy: STEP_IDS.INITIATE_SAML_PROFILE,
+        },
+        stepTitle: "Initiate Google SAML Profile",
+      },
+    ],
+    outputs: [
+      { key: OUTPUT_KEYS.FLAG_M7_SAML_APP_SETTINGS_CONFIGURED, description: "SAML app settings configured" },
+    ],
+  },
+  urls: {
     configure: (outputs) => {
       const spId = outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.SAML_SSO_APP_ID];
       if (!spId || !appId) return null;
-      return portalUrls.azure.enterpriseApp.singleSignOn(
-        spId as string,
-        appId as string,
-      );
+      return portalUrls.azure.enterpriseApp.singleSignOn(spId as string, appId as string);
     },
     verify: (outputs) => {
       const spId = outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.SAML_SSO_APP_ID];
       if (!spId || !appId) return null;
-      return portalUrls.azure.enterpriseApp.singleSignOn(
-        spId as string,
-        appId as string,
-      );
+      return portalUrls.azure.enterpriseApp.singleSignOn(spId as string, appId as string);
     },
   },
-  check: checkConfigureSamlApp,
-  execute: executeConfigureSamlApp,
-};
+  handlers: { check: checkConfigureSamlApp, execute: executeConfigureSamlApp },
+});

--- a/lib/steps/microsoft/create-provisioning-app/index.ts
+++ b/lib/steps/microsoft/create-provisioning-app/index.ts
@@ -1,66 +1,41 @@
-import type { StepDefinition, StepInput, StepOutput } from "@/lib/types";
-import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
+import { STEP_IDS } from "@/lib/steps/step-refs";
+import { defineStep } from "@/lib/steps/utils/step-factory";
+import { OUTPUT_KEYS } from "@/lib/types";
 import { checkProvisioningApp } from "./check";
 import { executeCreateProvisioningApp } from "./execute";
-import { STEP_IDS } from "@/lib/steps/step-refs";
 
-export const M1_OUTPUTS: StepOutput[] = [
-  { key: OUTPUT_KEYS.PROVISIONING_APP_ID, description: "App (Client) ID" },
-  {
-    key: OUTPUT_KEYS.PROVISIONING_APP_OBJECT_ID,
-    description: "Application Object ID",
-  },
-  {
-    key: OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID,
-    description: "Service Principal Object ID",
-  },
-];
-
-export const M1_INPUTS: StepInput[] = [];
-
-export const m1CreateProvisioningApp: StepDefinition = {
+export const m1CreateProvisioningApp = defineStep({
   id: STEP_IDS.CREATE_PROVISIONING_APP,
-  title: "Create Azure AD Enterprise App for Provisioning",
-  description: "Add Google sync app from Microsoft's gallery",
-  details:
-    "Instantiates the Google Cloud/G Suite Connector by Microsoft gallery app. This creates an app registration and service principal used for provisioning users to Google Workspace.",
-
-  category: "Microsoft",
-  activity: "Provisioning",
-  provider: "Microsoft",
-
-  automatability: "automated",
-  automatable: true,
-
-  inputs: M1_INPUTS,
-  outputs: M1_OUTPUTS,
-  requires: [],
-  nextStep: {
-    id: STEP_IDS.ENABLE_PROVISIONING_SP,
-    description: "Enable the service principal",
+  metadata: {
+    title: "Create Azure AD Enterprise App for Provisioning",
+    description: "Add Google sync app from Microsoft's gallery",
+    category: "Microsoft",
+    activity: "Provisioning",
+    provider: "Microsoft",
+    automatability: "automated",
   },
-  actions: ["POST /applicationTemplates/{templateId}/instantiate"],
-  adminUrls: {
+  io: {
+    inputs: [],
+    outputs: [
+      { key: OUTPUT_KEYS.PROVISIONING_APP_ID, description: "App (Client) ID" },
+      { key: OUTPUT_KEYS.PROVISIONING_APP_OBJECT_ID, description: "Application Object ID" },
+      { key: OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID, description: "Service Principal Object ID" },
+    ],
+  },
+  urls: {
     configure: (outputs) => {
       const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
       if (!spId || !appId) return null;
-      return portalUrls.azure.enterpriseApp.overview(
-        spId as string,
-        appId as string,
-      );
+      return portalUrls.azure.enterpriseApp.overview(spId as string, appId as string);
     },
     verify: (outputs) => {
       const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
       if (!spId || !appId) return null;
-      return portalUrls.azure.enterpriseApp.overview(
-        spId as string,
-        appId as string,
-      );
+      return portalUrls.azure.enterpriseApp.overview(spId as string, appId as string);
     },
   },
-  check: checkProvisioningApp,
-  execute: executeCreateProvisioningApp,
-};
+  handlers: { check: checkProvisioningApp, execute: executeCreateProvisioningApp },
+});

--- a/lib/steps/microsoft/create-saml-app/index.ts
+++ b/lib/steps/microsoft/create-saml-app/index.ts
@@ -1,66 +1,42 @@
-import type { StepDefinition, StepInput, StepOutput } from "@/lib/types";
-import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
+import { STEP_IDS } from "@/lib/steps/step-refs";
+import { defineStep } from "@/lib/steps/utils/step-factory";
+import { OUTPUT_KEYS } from "@/lib/types";
 import { checkCreateSamlApp } from "./check";
 import { executeCreateSamlApp } from "./execute";
-import { STEP_IDS } from "@/lib/steps/step-refs";
 
-export const M6_OUTPUTS: StepOutput[] = [
-  { key: OUTPUT_KEYS.SAML_SSO_APP_ID, description: "App (Client) ID" },
-  {
-    key: OUTPUT_KEYS.SAML_SSO_APP_OBJECT_ID,
-    description: "Application Object ID",
-  },
-  {
-    key: OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID,
-    description: "Service Principal ID",
-  },
-];
-
-export const M6_INPUTS: StepInput[] = [];
-
-export const m6CreateSamlApp: StepDefinition = {
+export const m6CreateSamlApp = defineStep({
   id: STEP_IDS.CREATE_SAML_APP,
-  title: "Create Azure AD Enterprise App for SAML SSO",
-  description: "Add a second Google app for single sign-on",
-  details:
-    "Creates a second gallery application specifically for SAML-based single sign-on with Google Workspace. This generates a new application registration and service principal that will handle SSO requests.",
-
-  category: "Microsoft",
-  activity: "SSO",
-  provider: "Microsoft",
-
-  automatability: "automated",
-  automatable: true,
-
-  inputs: M6_INPUTS,
-  outputs: M6_OUTPUTS,
-  requires: [STEP_IDS.START_PROVISIONING],
-  nextStep: {
-    id: STEP_IDS.CONFIGURE_SAML_APP,
-    description: "Configure SAML settings",
+  metadata: {
+    title: "Create Azure AD Enterprise App for SAML SSO",
+    description: "Add a second Google app for single sign-on",
+    category: "Microsoft",
+    activity: "SSO",
+    provider: "Microsoft",
+    automatability: "automated",
+    requires: [STEP_IDS.START_PROVISIONING],
   },
-  actions: ["POST /applicationTemplates/{templateId}/instantiate"],
-  adminUrls: {
+  io: {
+    inputs: [],
+    outputs: [
+      { key: OUTPUT_KEYS.SAML_SSO_APP_ID, description: "App (Client) ID" },
+      { key: OUTPUT_KEYS.SAML_SSO_APP_OBJECT_ID, description: "Application Object ID" },
+      { key: OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID, description: "Service Principal ID" },
+    ],
+  },
+  urls: {
     configure: (outputs) => {
       const spId = outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.SAML_SSO_APP_ID];
       if (!spId || !appId) return null;
-      return portalUrls.azure.enterpriseApp.overview(
-        spId as string,
-        appId as string,
-      );
+      return portalUrls.azure.enterpriseApp.overview(spId as string, appId as string);
     },
     verify: (outputs) => {
       const spId = outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.SAML_SSO_APP_ID];
       if (!spId || !appId) return null;
-      return portalUrls.azure.enterpriseApp.overview(
-        spId as string,
-        appId as string,
-      );
+      return portalUrls.azure.enterpriseApp.overview(spId as string, appId as string);
     },
   },
-  check: checkCreateSamlApp,
-  execute: executeCreateSamlApp,
-};
+  handlers: { check: checkCreateSamlApp, execute: executeCreateSamlApp },
+});

--- a/lib/steps/microsoft/enable-provisioning-sp/index.ts
+++ b/lib/steps/microsoft/enable-provisioning-sp/index.ts
@@ -1,80 +1,59 @@
-import type { StepDefinition, StepInput, StepOutput } from "@/lib/types";
-import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
+import { STEP_IDS } from "@/lib/steps/step-refs";
+import { defineStep } from "@/lib/steps/utils/step-factory";
+import { OUTPUT_KEYS } from "@/lib/types";
 import { checkEnableProvisioningSp } from "./check";
 import { executeEnableProvisioningSp } from "./execute";
-import { STEP_IDS } from "@/lib/steps/step-refs";
 
-export const M2_OUTPUTS: StepOutput[] = [
-  {
-    key: OUTPUT_KEYS.FLAG_M2_PROV_APP_PROPS_CONFIGURED,
-    description: "Provisioning app enabled",
-  },
-];
-
-export const M2_INPUTS: StepInput[] = [
-  {
-    type: "keyValue",
-    data: {
-      key: OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID,
-      description: "Service principal object ID",
-      producedBy: STEP_IDS.CREATE_PROVISIONING_APP,
-    },
-    stepTitle: "Create Provisioning App",
-  },
-  {
-    type: "keyValue",
-    data: {
-      key: OUTPUT_KEYS.PROVISIONING_APP_ID,
-      description: "Provisioning app ID",
-      producedBy: STEP_IDS.CREATE_PROVISIONING_APP,
-    },
-    stepTitle: "Create Provisioning App",
-  },
-];
-
-export const m2EnableProvisioningSp: StepDefinition = {
+export const m2EnableProvisioningSp = defineStep({
   id: STEP_IDS.ENABLE_PROVISIONING_SP,
-  title: "Enable Provisioning App Service Principal",
-  description: "Enable the sync app",
-  details:
-    "Enables the service principal created by the gallery app so that it can accept credentials and configuration settings.",
-
-  category: "Microsoft",
-  activity: "Provisioning",
-  provider: "Microsoft",
-
-  automatability: "automated",
-  automatable: true,
-
-  inputs: M2_INPUTS,
-  outputs: M2_OUTPUTS,
-  requires: [STEP_IDS.CREATE_PROVISIONING_APP],
-  nextStep: {
-    id: STEP_IDS.AUTHORIZE_PROVISIONING,
-    description: "Authorize provisioning using Google admin",
+  metadata: {
+    title: "Enable Provisioning App Service Principal",
+    description: "Enable the sync app",
+    category: "Microsoft",
+    activity: "Provisioning",
+    provider: "Microsoft",
+    automatability: "automated",
+    requires: [STEP_IDS.CREATE_PROVISIONING_APP],
   },
-  actions: ["PATCH /servicePrincipals/{id}"],
-  adminUrls: {
+  io: {
+    inputs: [
+      {
+        type: "keyValue",
+        data: {
+          key: OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID,
+          description: "Service principal object ID",
+          producedBy: STEP_IDS.CREATE_PROVISIONING_APP,
+        },
+        stepTitle: "Create Provisioning App",
+      },
+      {
+        type: "keyValue",
+        data: {
+          key: OUTPUT_KEYS.PROVISIONING_APP_ID,
+          description: "Provisioning app ID",
+          producedBy: STEP_IDS.CREATE_PROVISIONING_APP,
+        },
+        stepTitle: "Create Provisioning App",
+      },
+    ],
+    outputs: [
+      { key: OUTPUT_KEYS.FLAG_M2_PROV_APP_PROPS_CONFIGURED, description: "Provisioning app enabled" },
+    ],
+  },
+  urls: {
     configure: (outputs) => {
       const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
       if (!spId || !appId) return null;
-      return portalUrls.azure.enterpriseApp.overview(
-        spId as string,
-        appId as string,
-      );
+      return portalUrls.azure.enterpriseApp.overview(spId as string, appId as string);
     },
     verify: (outputs) => {
       const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
       if (!spId || !appId) return null;
-      return portalUrls.azure.enterpriseApp.overview(
-        spId as string,
-        appId as string,
-      );
+      return portalUrls.azure.enterpriseApp.overview(spId as string, appId as string);
     },
   },
-  check: checkEnableProvisioningSp,
-  execute: executeEnableProvisioningSp,
-};
+  handlers: { check: checkEnableProvisioningSp, execute: executeEnableProvisioningSp },
+});

--- a/lib/steps/microsoft/retrieve-idp-metadata/index.ts
+++ b/lib/steps/microsoft/retrieve-idp-metadata/index.ts
@@ -1,79 +1,61 @@
-import type { StepDefinition, StepInput, StepOutput } from "@/lib/types";
-import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
+import { STEP_IDS } from "@/lib/steps/step-refs";
+import { defineStep } from "@/lib/steps/utils/step-factory";
+import { OUTPUT_KEYS } from "@/lib/types";
 import { checkIdpMetadata } from "./check";
 import { executeRetrieveIdpMetadata } from "./execute";
-import { STEP_IDS } from "@/lib/steps/step-refs";
 
-export const M8_OUTPUTS: StepOutput[] = [
-  { key: OUTPUT_KEYS.IDP_CERTIFICATE_BASE64, description: "IdP certificate" },
-  { key: OUTPUT_KEYS.IDP_SSO_URL, description: "IdP SSO URL" },
-  { key: OUTPUT_KEYS.IDP_ENTITY_ID, description: "IdP entity ID" },
-];
-
-export const M8_INPUTS: StepInput[] = [
-  {
-    type: "keyValue",
-    data: {
-      key: OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID,
-      description: "SAML SP object ID",
-      producedBy: STEP_IDS.CREATE_SAML_APP,
-    },
-    stepTitle: "Create SAML App",
-  },
-  {
-    type: "keyValue",
-    data: {
-      key: OUTPUT_KEYS.SAML_SSO_APP_ID,
-      description: "SAML app ID",
-      producedBy: STEP_IDS.CREATE_SAML_APP,
-    },
-    stepTitle: "Create SAML App",
-  },
-];
-
-export const m8RetrieveIdpMetadata: StepDefinition = {
+export const m8RetrieveIdpMetadata = defineStep({
   id: STEP_IDS.RETRIEVE_IDP_METADATA,
-  title: "Retrieve Azure AD IdP SAML Metadata for Google",
-  description: "Get Microsoft's sign-on details for Google",
-  details:
-    "Retrieves the Azure AD SAML metadata XML which includes the IdP entity ID, sign-in URL, and certificate. Google Workspace uses this data to trust Azure AD as the identity provider.",
-
-  category: "Microsoft",
-  activity: "SSO",
-  provider: "Microsoft",
-
-  automatability: "automated",
-  automatable: true,
-
-  inputs: M8_INPUTS,
-  outputs: M8_OUTPUTS,
-  requires: [STEP_IDS.CONFIGURE_SAML_APP],
-  nextStep: {
-    id: STEP_IDS.ASSIGN_USERS_SSO,
-    description: "Assign users to SSO app",
+  metadata: {
+    title: "Retrieve Azure AD IdP SAML Metadata for Google",
+    description: "Get Microsoft's sign-on details for Google",
+    category: "Microsoft",
+    activity: "SSO",
+    provider: "Microsoft",
+    automatability: "automated",
+    requires: [STEP_IDS.CONFIGURE_SAML_APP],
   },
-  actions: ["GET /federationmetadata/2007-06/federationmetadata.xml"],
-  adminUrls: {
+  io: {
+    inputs: [
+      {
+        type: "keyValue",
+        data: {
+          key: OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID,
+          description: "SAML SP object ID",
+          producedBy: STEP_IDS.CREATE_SAML_APP,
+        },
+        stepTitle: "Create SAML App",
+      },
+      {
+        type: "keyValue",
+        data: {
+          key: OUTPUT_KEYS.SAML_SSO_APP_ID,
+          description: "SAML app ID",
+          producedBy: STEP_IDS.CREATE_SAML_APP,
+        },
+        stepTitle: "Create SAML App",
+      },
+    ],
+    outputs: [
+      { key: OUTPUT_KEYS.IDP_CERTIFICATE_BASE64, description: "IdP certificate" },
+      { key: OUTPUT_KEYS.IDP_SSO_URL, description: "IdP SSO URL" },
+      { key: OUTPUT_KEYS.IDP_ENTITY_ID, description: "IdP entity ID" },
+    ],
+  },
+  urls: {
     configure: (outputs) => {
       const spId = outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.SAML_SSO_APP_ID];
       if (!spId || !appId) return null;
-      return portalUrls.azure.enterpriseApp.singleSignOn(
-        spId as string,
-        appId as string,
-      );
+      return portalUrls.azure.enterpriseApp.singleSignOn(spId as string, appId as string);
     },
     verify: (outputs) => {
       const spId = outputs[OUTPUT_KEYS.SAML_SSO_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.SAML_SSO_APP_ID];
       if (!spId || !appId) return null;
-      return portalUrls.azure.enterpriseApp.singleSignOn(
-        spId as string,
-        appId as string,
-      );
+      return portalUrls.azure.enterpriseApp.singleSignOn(spId as string, appId as string);
     },
   },
-  check: checkIdpMetadata,
-  execute: executeRetrieveIdpMetadata,
-};
+  handlers: { check: checkIdpMetadata, execute: executeRetrieveIdpMetadata },
+});

--- a/lib/steps/microsoft/start-provisioning/index.ts
+++ b/lib/steps/microsoft/start-provisioning/index.ts
@@ -1,83 +1,66 @@
-import type { StepDefinition, StepInput, StepOutput } from "@/lib/types";
-import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
+import { STEP_IDS } from "@/lib/steps/step-refs";
+import { defineStep } from "@/lib/steps/utils/step-factory";
+import { OUTPUT_KEYS } from "@/lib/types";
 import { checkStartProvisioning } from "./check";
 import { executeStartProvisioning } from "./execute";
-import { STEP_IDS } from "@/lib/steps/step-refs";
 
-export const M5_OUTPUTS: StepOutput[] = [];
-
-export const M5_INPUTS: StepInput[] = [
-  {
-    type: "keyValue",
-    data: {
-      key: OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID,
-      description: "Service principal object ID",
-      producedBy: STEP_IDS.CREATE_PROVISIONING_APP,
-    },
-    stepTitle: "Create Provisioning App",
-  },
-  {
-    type: "keyValue",
-    data: {
-      key: OUTPUT_KEYS.PROVISIONING_JOB_ID,
-      description: "Provisioning job ID",
-      producedBy: STEP_IDS.AUTHORIZE_PROVISIONING,
-    },
-    stepTitle: "Authorize Provisioning",
-  },
-  {
-    type: "keyValue",
-    data: {
-      key: OUTPUT_KEYS.PROVISIONING_APP_ID,
-      description: "Provisioning app ID",
-      producedBy: STEP_IDS.CREATE_PROVISIONING_APP,
-    },
-    stepTitle: "Create Provisioning App",
-  },
-];
-
-export const m5StartProvisioning: StepDefinition = {
+export const m5StartProvisioning = defineStep({
   id: STEP_IDS.START_PROVISIONING,
-  title: "Define Scope & Start Provisioning Job",
-  description: "Start syncing users (configure who to sync first)",
-  details:
-    "Defines which users and groups should be provisioned and then starts the synchronization job in Azure AD. The initial sync may take several minutes to complete.",
-
-  category: "Microsoft",
-  activity: "Provisioning",
-  provider: "Microsoft",
-
-  automatability: "supervised",
-  automatable: true,
-  inputs: M5_INPUTS,
-  outputs: M5_OUTPUTS,
-  requires: [STEP_IDS.CONFIGURE_ATTRIBUTE_MAPPINGS],
-  nextStep: {
-    id: STEP_IDS.CREATE_SAML_APP,
-    description: "Create SAML app for SSO",
+  metadata: {
+    title: "Define Scope & Start Provisioning Job",
+    description: "Start syncing users (configure who to sync first)",
+    category: "Microsoft",
+    activity: "Provisioning",
+    provider: "Microsoft",
+    automatability: "supervised",
+    requires: [STEP_IDS.CONFIGURE_ATTRIBUTE_MAPPINGS],
   },
-  actions: ["POST /servicePrincipals/{id}/synchronization/jobs"],
-  adminUrls: {
+  io: {
+    inputs: [
+      {
+        type: "keyValue",
+        data: {
+          key: OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID,
+          description: "Service principal object ID",
+          producedBy: STEP_IDS.CREATE_PROVISIONING_APP,
+        },
+        stepTitle: "Create Provisioning App",
+      },
+      {
+        type: "keyValue",
+        data: {
+          key: OUTPUT_KEYS.PROVISIONING_JOB_ID,
+          description: "Provisioning job ID",
+          producedBy: STEP_IDS.AUTHORIZE_PROVISIONING,
+        },
+        stepTitle: "Authorize Provisioning",
+      },
+      {
+        type: "keyValue",
+        data: {
+          key: OUTPUT_KEYS.PROVISIONING_APP_ID,
+          description: "Provisioning app ID",
+          producedBy: STEP_IDS.CREATE_PROVISIONING_APP,
+        },
+        stepTitle: "Create Provisioning App",
+      },
+    ],
+    outputs: [],
+  },
+  urls: {
     configure: (outputs) => {
       const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
       if (!spId || !appId) return null;
-      return portalUrls.azure.enterpriseApp.provisioning(
-        spId as string,
-        appId as string,
-      );
+      return portalUrls.azure.enterpriseApp.provisioning(spId as string, appId as string);
     },
     verify: (outputs) => {
       const spId = outputs[OUTPUT_KEYS.PROVISIONING_SP_OBJECT_ID];
       const appId = outputs[OUTPUT_KEYS.PROVISIONING_APP_ID];
       if (!spId || !appId) return null;
-      return portalUrls.azure.enterpriseApp.provisioning(
-        spId as string,
-        appId as string,
-      );
+      return portalUrls.azure.enterpriseApp.provisioning(spId as string, appId as string);
     },
   },
-  check: checkStartProvisioning,
-  execute: executeStartProvisioning,
-};
+  handlers: { check: checkStartProvisioning, execute: executeStartProvisioning },
+});

--- a/lib/steps/microsoft/test-sso/index.ts
+++ b/lib/steps/microsoft/test-sso/index.ts
@@ -1,49 +1,40 @@
-import type { StepDefinition, StepInput, StepOutput } from "@/lib/types";
-import { OUTPUT_KEYS } from "@/lib/types";
 import { portalUrls } from "@/lib/api/url-builder";
+import { STEP_IDS } from "@/lib/steps/step-refs";
+import { defineStep } from "@/lib/steps/utils/step-factory";
+import { OUTPUT_KEYS } from "@/lib/types";
 import { checkTestSso } from "./check";
 import { executeTestSso } from "./execute";
-import { STEP_IDS } from "@/lib/steps/step-refs";
 
-export const M10_OUTPUTS: StepOutput[] = [
-  { key: OUTPUT_KEYS.FLAG_M10_SSO_TESTED, description: "SSO tested" },
-];
-
-export const M10_INPUTS: StepInput[] = [
-  {
-    type: "keyValue",
-    data: {
-      key: OUTPUT_KEYS.SAML_SSO_APP_ID,
-      description: "SSO app ID",
-      producedBy: STEP_IDS.CREATE_SAML_APP,
-    },
-    stepTitle: "Create SAML App",
-  },
-];
-
-export const m10TestSso: StepDefinition = {
+export const m10TestSso = defineStep({
   id: STEP_IDS.TEST_SSO,
-  title: "Test & Validate SSO Sign-in",
-  description: "Test signing in with a Microsoft account",
-  details:
-    "Tests the entire single sign-on flow using an assigned user account to ensure that authentication works end-to-end. This confirms that both provisioning and SSO have been configured correctly.",
-
-  category: "Microsoft",
-  activity: "SSO",
-  provider: "Microsoft",
-
-  automatability: "manual",
-  automatable: false,
-
-  inputs: M10_INPUTS,
-  outputs: M10_OUTPUTS,
-  requires: [STEP_IDS.ASSIGN_SAML_PROFILE, STEP_IDS.ASSIGN_USERS_SSO],
-  nextStep: undefined,
-  actions: ["Manual: Use 'Test' button in portal"],
-  adminUrls: {
+  metadata: {
+    title: "Test & Validate SSO Sign-in",
+    description: "Test signing in with a Microsoft account",
+    category: "Microsoft",
+    activity: "SSO",
+    provider: "Microsoft",
+    automatability: "manual",
+    requires: [STEP_IDS.ASSIGN_SAML_PROFILE, STEP_IDS.ASSIGN_USERS_SSO],
+  },
+  io: {
+    inputs: [
+      {
+        type: "keyValue",
+        data: {
+          key: OUTPUT_KEYS.SAML_SSO_APP_ID,
+          description: "SSO app ID",
+          producedBy: STEP_IDS.CREATE_SAML_APP,
+        },
+        stepTitle: "Create SAML App",
+      },
+    ],
+    outputs: [
+      { key: OUTPUT_KEYS.FLAG_M10_SSO_TESTED, description: "SSO tested" },
+    ],
+  },
+  urls: {
     configure: portalUrls.azure.myApps(),
     verify: portalUrls.azure.myApps(),
   },
-  check: checkTestSso,
-  execute: executeTestSso,
-};
+  handlers: { check: checkTestSso, execute: executeTestSso },
+});

--- a/lib/steps/step-content-updates.ts
+++ b/lib/steps/step-content-updates.ts
@@ -1,7 +1,14 @@
 // This file contains the enhanced descriptions, details, and metadata for all steps
 import { STEP_IDS } from "@/lib/steps/step-refs";
+import type { StepId } from "./step-refs";
 
-export const stepContentEnhancements = {
+export interface StepContent {
+  details: string;
+  actions: string[];
+  nextStep?: { id: StepId; description: string };
+}
+
+export const stepContentEnhancements: Record<StepId, StepContent> = {
   [STEP_IDS.CREATE_AUTOMATION_OU]: {
     details:
       "Creates an organizational unit at the root level of your Google Workspace directory. This OU will contain service accounts and other automation-related users, keeping them separate from regular users for security and organization.",

--- a/lib/steps/utils/step-factory.ts
+++ b/lib/steps/utils/step-factory.ts
@@ -1,0 +1,63 @@
+import { stepContentEnhancements, StepContent } from "../step-content-updates";
+import type {
+  StepDefinition,
+  StepInput,
+  StepOutput,
+  StepContext,
+  StepCheckResult,
+  StepExecutionResult,
+} from "@/lib/types";
+import type { StepId } from "../step-refs";
+
+export type CheckFn = (context: StepContext) => Promise<StepCheckResult>;
+export type ExecuteFn = (context: StepContext) => Promise<StepExecutionResult>;
+
+export type StepUrls = StepDefinition["adminUrls"];
+
+export interface StepMetadata {
+  title: string;
+  description: string;
+  category: StepDefinition["category"];
+  activity: StepDefinition["activity"];
+  provider?: StepDefinition["provider"];
+  automatability?: StepDefinition["automatability"];
+  requires?: StepId[];
+}
+
+function inferProvider(id: StepId): StepDefinition["provider"] {
+  return id.startsWith("G-") ? "Google" : "Microsoft";
+}
+
+export function defineStep<TInputs extends StepInput[], TOutputs extends StepOutput[]>(
+  config: {
+    id: StepId;
+    metadata: StepMetadata;
+    io: { inputs: TInputs; outputs: TOutputs };
+    handlers: { check: CheckFn; execute: ExecuteFn };
+    urls?: StepUrls;
+  },
+): StepDefinition {
+  const enhancement: StepContent = stepContentEnhancements[config.id] || { details: "", actions: [] };
+  const provider = config.metadata.provider ?? inferProvider(config.id);
+  const automatability = config.metadata.automatability ?? "automated";
+
+  return {
+    id: config.id,
+    title: config.metadata.title,
+    description: config.metadata.description,
+    details: enhancement.details,
+    category: config.metadata.category,
+    activity: config.metadata.activity,
+    provider,
+    automatability,
+    automatable: automatability !== "manual",
+    requires: config.metadata.requires,
+    inputs: config.io.inputs,
+    outputs: config.io.outputs,
+    nextStep: enhancement.nextStep,
+    actions: enhancement.actions,
+    adminUrls: config.urls,
+    check: config.handlers.check,
+    execute: config.handlers.execute,
+  };
+}

--- a/test/mocks/handlers/google.ts
+++ b/test/mocks/handlers/google.ts
@@ -2,7 +2,7 @@ import { http, HttpResponse } from 'msw'
 
 export const googleHandlers = [
   http.post('https://admin.googleapis.com/admin/directory/v1/users', async ({ request }) => {
-    const body: any = await request.json()
+    const body: Record<string, unknown> = await request.json()
     return HttpResponse.json({
       id: 'mock-user-id',
       primaryEmail: body.primaryEmail,
@@ -24,7 +24,7 @@ export const googleHandlers = [
   }),
 
   http.post('https://admin.googleapis.com/admin/directory/v1/customer/:customerId/orgunits', async ({ request }) => {
-    const body: any = await request.json()
+    const body: Record<string, unknown> = await request.json()
     return HttpResponse.json({
       orgUnitId: 'mock-ou-id',
       orgUnitPath: `/${body.name}`,


### PR DESCRIPTION
## Summary
- add `defineStep` factory utility for creating step definitions
- refactor all step `index.ts` files to use the new factory
- type step content updates and use from factory
- adjust jest setup and test mocks for lint

## Testing
- `pnpm lint --fix`
- `pnpm type-check` *(fails: cannot find debug-panel, etc.)*
- `pnpm build` *(fails: cannot find debug-panel module)*

------
https://chatgpt.com/codex/tasks/task_e_68414d3e99c08322b85221386e552d0b