### PR TITLE
Add route loading boundaries

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,8 @@
 import { auth } from "@/app/(auth)/auth";
 import { AutomationDashboard } from "@/components/dashboard";
 import { InitialConfigLoader } from "@/components/initial-config-loader";
-import { redirect } from "next/navigation";
 import { RouteGuard } from "@/components/route-guard";
+import { redirect } from "next/navigation";
 
 /**
  * Server component that renders the automation dashboard once both providers
@@ -12,7 +12,9 @@ export default async function Page() {
   const session = await auth();
 
   if (!session?.user) {
-    redirect("/login?reason=unauthenticated");
+    // Client-side RouteGuard will handle the redirect and display a loading
+    // spinner while the authentication state resolves.
+    return <RouteGuard>{null}</RouteGuard>;
   }
 
   // Redirect if either provider is missing.

--- a/components/route-guard.tsx
+++ b/components/route-guard.tsx
@@ -19,7 +19,9 @@ export function RouteGuard({ children, requireAuth = true }: RouteGuardProps) {
     }
   }, [requireAuth, status, router]);
 
-  if (requireAuth && status === "loading") {
+  if (requireAuth && (status === "loading" || status === "unauthenticated")) {
+    // Display a full-screen spinner while the auth status resolves or during
+    // client-side redirects to avoid flashing the protected content.
     return <LoadingSpinner fullScreen />;
   }
 


### PR DESCRIPTION
## Summary
- show spinner during auth check in `<RouteGuard>`
- render `<RouteGuard>` on `/` server page instead of redirecting immediately

## Testing
- `pnpm lint --fix`
- `pnpm type-check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68415138d7708322a58337d18bffb641