### PR TITLE
Refactor selectors to avoid unnecessary re-renders

### DIFF
--- a/components/auth.tsx
+++ b/components/auth.tsx
@@ -25,7 +25,8 @@ import { useErrorHandler } from "@/hooks/use-error-handler";
  */
 export function AuthStatus() {
   const { data: session, status } = useSession();
-  const { domain, tenantId } = useAppSelector((state) => state.app);
+  const domain = useAppSelector((state) => state.app.domain);
+  const tenantId = useAppSelector((state) => state.app.tenantId);
   const { handleError } = useErrorHandler();
 
   const isConfigReady = !!domain && !!tenantId;

--- a/components/dashboard/action-toolbar.tsx
+++ b/components/dashboard/action-toolbar.tsx
@@ -14,10 +14,11 @@ interface ActionToolbarProps {
 }
 
 export function ActionToolbar({ session, isLoadingSession }: ActionToolbarProps) {
-  const appConfig = useAppSelector((state) => state.app);
+  const domain = useAppSelector((state) => state.app.domain);
+  const tenantId = useAppSelector((state) => state.app.tenantId);
   const showActionRequired =
-    (!appConfig.domain ||
-      !appConfig.tenantId ||
+    (!domain ||
+      !tenantId ||
       !session?.hasGoogleAuth ||
       !session?.hasMicrosoftAuth) &&
     !isLoadingSession;
@@ -36,17 +37,17 @@ export function ActionToolbar({ session, isLoadingSession }: ActionToolbarProps)
           <AlertTitle className="font-semibold">Action Required</AlertTitle>
           <AlertDescription>
             <ul className="mt-1 space-y-1 list-disc pl-5">
-              {!appConfig.domain && !session?.authFlowDomain && (
+              {!domain && !session?.authFlowDomain && (
                 <li>Sign in with Google to detect your domain</li>
               )}
-              {!appConfig.tenantId && !session?.microsoftTenantId && (
+              {!tenantId && !session?.microsoftTenantId && (
                 <li>Sign in with Microsoft to detect your Tenant ID</li>
               )}
-              {(appConfig.domain || session?.authFlowDomain) &&
-                (appConfig.tenantId || session?.microsoftTenantId) &&
+              {(domain || session?.authFlowDomain) &&
+                (tenantId || session?.microsoftTenantId) &&
                 !session?.hasGoogleAuth && <li>Connect to Google Workspace.</li>}
-              {(appConfig.domain || session?.authFlowDomain) &&
-                (appConfig.tenantId || session?.microsoftTenantId) &&
+              {(domain || session?.authFlowDomain) &&
+                (tenantId || session?.microsoftTenantId) &&
                 !session?.hasMicrosoftAuth && <li>Connect to Microsoft Entra ID.</li>}
             </ul>
             <p className="mt-2">Complete all requirements to continue</p>

--- a/components/dashboard/hooks/use-progress-persistence.ts
+++ b/components/dashboard/hooks/use-progress-persistence.ts
@@ -9,12 +9,12 @@ import type { RootState } from "@/lib/redux/store";
 export function useProgressPersistence() {
   const dispatch = useAppDispatch();
   const store = useStore<RootState>();
-  const appConfig = useAppSelector((state: RootState) => state.app);
+  const domain = useAppSelector((state: RootState) => state.app.domain);
   const stepsStatusMap = useAppSelector((state: RootState) => state.app.steps);
 
   useEffect(() => {
-    if (appConfig.domain && appConfig.domain !== "") {
-      const persisted: PersistedProgress | null = loadProgress(appConfig.domain);
+    if (domain && domain !== "") {
+      const persisted: PersistedProgress | null = loadProgress(domain);
       if (persisted) {
         dispatch(initializeSteps(persisted.steps));
         dispatch(addOutputs(persisted.outputs || {}));
@@ -26,14 +26,14 @@ export function useProgressPersistence() {
         dispatch(initializeSteps(initialStatuses));
       }
     }
-  }, [appConfig.domain, dispatch]);
+  }, [domain, dispatch]);
 
   useEffect(() => {
-    if (appConfig.domain && appConfig.domain !== "") {
-      void saveProgress(appConfig.domain, {
+    if (domain && domain !== "") {
+      void saveProgress(domain, {
         steps: stepsStatusMap,
         outputs: store.getState().app.outputs,
       });
     }
-  }, [appConfig.domain, stepsStatusMap, store]);
+  }, [domain, stepsStatusMap, store]);
 }

--- a/components/dashboard/hooks/use-step-runner.ts
+++ b/components/dashboard/hooks/use-step-runner.ts
@@ -16,7 +16,8 @@ export function useStepRunner() {
   const { session, status } = useSessionSync();
   const dispatch = useAppDispatch();
   const store = useStore<RootState>();
-  const appConfig = useAppSelector((state: RootState) => state.app);
+  const domain = useAppSelector((state: RootState) => state.app.domain);
+  const tenantId = useAppSelector((state: RootState) => state.app.tenantId);
 
   const currentSession = session;
   const canRunAutomation = useMemo(
@@ -24,10 +25,10 @@ export function useStepRunner() {
       !!(
         currentSession?.hasGoogleAuth &&
         currentSession?.hasMicrosoftAuth &&
-        appConfig.domain &&
-        appConfig.tenantId
+        domain &&
+        tenantId
       ),
-    [currentSession?.hasGoogleAuth, currentSession?.hasMicrosoftAuth, appConfig.domain, appConfig.tenantId]
+    [currentSession?.hasGoogleAuth, currentSession?.hasMicrosoftAuth, domain, tenantId]
   );
 
   const { executeStep } = useStepExecution();
@@ -47,7 +48,7 @@ export function useStepRunner() {
 
   const executeCheck = useCallback(
     async (stepId: StepId): Promise<StepCheckResult> => {
-      if (!appConfig.domain || !appConfig.tenantId) {
+      if (!domain || !tenantId) {
         return { completed: false } as StepCheckResult;
       }
 
@@ -56,8 +57,8 @@ export function useStepRunner() {
       );
 
       const context: StepContext = {
-        domain: appConfig.domain,
-        tenantId: appConfig.tenantId,
+        domain,
+        tenantId,
         outputs: store.getState().app.outputs,
       };
 
@@ -158,7 +159,7 @@ export function useStepRunner() {
         return { completed: false } as StepCheckResult;
       }
     },
-    [appConfig.domain, appConfig.tenantId, dispatch, store]
+    [domain, tenantId, dispatch, store]
   );
 
   const { manualRefresh, isChecking } = useAutoCheck(executeCheck);

--- a/components/dashboard/session-guard.tsx
+++ b/components/dashboard/session-guard.tsx
@@ -15,7 +15,8 @@ interface SessionGuardProps {
 
 export function SessionGuard({ serverSession, children }: SessionGuardProps) {
   const { session, status } = useSessionSync();
-  const appConfig = useAppSelector((state) => state.app);
+  const domain = useAppSelector((state) => state.app.domain);
+  const tenantId = useAppSelector((state) => state.app.tenantId);
   const isLoading = status === "loading";
   const currentSession = session ?? serverSession;
 
@@ -34,7 +35,7 @@ export function SessionGuard({ serverSession, children }: SessionGuardProps) {
       !session?.hasMicrosoftAuth ||
       (session?.error as unknown as string) === "MissingTokens" ||
       session?.error === "RefreshTokenError") &&
-    (appConfig.domain || appConfig.tenantId)
+    (domain || tenantId)
   ) {
     return (
       <div className="min-h-screen bg-slate-50 dark:bg-slate-900 p-8">

--- a/components/form.tsx
+++ b/components/form.tsx
@@ -34,9 +34,8 @@ type ConfigFormData = z.infer<typeof configFormSchema>;
  */
 
 export function ConfigForm() {
-  const currentAppConfig = useAppSelector(
-    (state: RootState) => state.app,
-  );
+  const domain = useAppSelector((state: RootState) => state.app.domain);
+  const tenantId = useAppSelector((state: RootState) => state.app.tenantId);
 
   const {
     register,
@@ -45,8 +44,8 @@ export function ConfigForm() {
   } = useForm<ConfigFormData>({
     resolver: zodResolver(configFormSchema),
     defaultValues: {
-      domain: currentAppConfig.domain ?? "",
-      tenantId: currentAppConfig.tenantId ?? "",
+      domain: domain ?? "",
+      tenantId: tenantId ?? "",
     },
   });
 
@@ -54,16 +53,15 @@ export function ConfigForm() {
   useEffect(() => {
     console.log(
       "ConfigForm: Resetting/populating form with Redux state:",
-      currentAppConfig,
+      { domain, tenantId },
     );
     reset({
-      domain: currentAppConfig.domain ?? "",
-      tenantId: currentAppConfig.tenantId ?? "",
+      domain: domain ?? "",
+      tenantId: tenantId ?? "",
     });
   }, [
-    currentAppConfig,
-    currentAppConfig.domain,
-    currentAppConfig.tenantId,
+    domain,
+    tenantId,
     reset,
   ]);
 

--- a/components/progress.tsx
+++ b/components/progress.tsx
@@ -19,8 +19,10 @@ interface ProgressVisualizerProps {
 
 export function ProgressVisualizer({ onExecuteStep }: ProgressVisualizerProps) {
   const stepsStatusMap = useAppSelector((state) => state.app.steps);
-  const appConfig = useAppSelector((state) => state.app);
-  const canRunGlobalSteps = !!(appConfig.domain && appConfig.tenantId);
+  const domain = useAppSelector((state) => state.app.domain);
+  const tenantId = useAppSelector((state) => state.app.tenantId);
+  const outputs = useAppSelector((state) => state.app.outputs);
+  const canRunGlobalSteps = !!(domain && tenantId);
 
   const managedSteps: ManagedStep[] = React.useMemo(() => {
     return allStepDefinitions.map((definition) => {
@@ -114,7 +116,7 @@ export function ProgressVisualizer({ onExecuteStep }: ProgressVisualizerProps) {
                 <WorkflowStepCard
                   key={step.id}
                   step={step}
-                  allOutputs={appConfig.outputs}
+                  allOutputs={outputs}
                   onExecute={onExecuteStep}
                   canRunGlobal={canRunGlobalSteps}
                   stepInputDefs={getStepInputs(

--- a/hooks/use-auto-check.ts
+++ b/hooks/use-auto-check.ts
@@ -12,7 +12,8 @@ import { debounce } from "@/lib/utils";
 export function useAutoCheck(
   executeCheck: (stepId: StepId) => Promise<StepCheckResult>,
 ) {
-  const appConfig = useAppSelector((state) => state.app);
+  const domain = useAppSelector((state) => state.app.domain);
+  const tenantId = useAppSelector((state) => state.app.tenantId);
   const stepsStatus = useAppSelector((state) => state.app.steps);
 
   const checkedSteps = useRef(new Set<StepId>());
@@ -22,7 +23,7 @@ export function useAutoCheck(
   const runChecks = useCallback(
     async (force = false) => {
       if (isCheckingRef.current) return;
-      if (!appConfig.domain || !appConfig.tenantId) return;
+      if (!domain || !tenantId) return;
 
       isCheckingRef.current = true;
       setIsChecking(true);
@@ -57,16 +58,16 @@ export function useAutoCheck(
       isCheckingRef.current = false;
       setIsChecking(false);
     },
-    [executeCheck, appConfig.domain, appConfig.tenantId, stepsStatus],
+    [executeCheck, domain, tenantId, stepsStatus],
   );
 
   const debouncedRunChecks = useRef(debounce(() => runChecks(false), 5000));
 
   useEffect(() => {
-    if (appConfig.domain && appConfig.tenantId) {
+    if (domain && tenantId) {
       debouncedRunChecks.current();
     }
-  }, [appConfig.domain, appConfig.tenantId]);
+  }, [domain, tenantId]);
 
   const manualRefresh = useCallback(async () => {
     checkedSteps.current.clear();

--- a/hooks/use-session-state.ts
+++ b/hooks/use-session-state.ts
@@ -19,23 +19,24 @@ interface SessionState {
 export function useSessionState(): SessionState {
   const { data: session, status, update } = useSession();
   const dispatch = useAppDispatch();
-  const appConfig = useAppSelector((state) => state.app);
+  const domain = useAppSelector((state) => state.app.domain);
+  const tenantId = useAppSelector((state) => state.app.tenantId);
   const lastValidation = useRef<number>(Date.now());
 
   useEffect(() => {
     if (
       session?.authFlowDomain &&
-      session.authFlowDomain !== appConfig.domain
+      session.authFlowDomain !== domain
     ) {
       dispatch(setDomain(session.authFlowDomain));
     }
     if (
       session?.microsoftTenantId &&
-      session.microsoftTenantId !== appConfig.tenantId
+      session.microsoftTenantId !== tenantId
     ) {
       dispatch(setTenantId(session.microsoftTenantId));
     }
-  }, [session, dispatch, appConfig.domain, appConfig.tenantId]);
+  }, [session, dispatch, domain, tenantId]);
 
   useEffect(() => {
     const interval = setInterval(async () => {

--- a/hooks/use-session-sync.ts
+++ b/hooks/use-session-sync.ts
@@ -16,7 +16,8 @@ export function useSessionSync() {
   const dispatch = useAppDispatch();
   const { handleError } = useErrorHandler();
   const lastCheckRef = useRef<number>(Date.now());
-  const appConfig = useAppSelector((state) => state.app);
+  const domain = useAppSelector((state) => state.app.domain);
+  const tenantId = useAppSelector((state) => state.app.tenantId);
 
   useEffect(() => {
     const checkInterval = setInterval(async () => {
@@ -36,14 +37,14 @@ export function useSessionSync() {
 
   useEffect(() => {
     if (session && status === "authenticated") {
-      if (session.authFlowDomain && !appConfig.domain) {
+      if (session.authFlowDomain && !domain) {
         console.log(
           "Syncing domain from session to Redux:",
           session.authFlowDomain,
         );
         dispatch(setDomain(session.authFlowDomain));
       }
-      if (session.microsoftTenantId && !appConfig.tenantId) {
+      if (session.microsoftTenantId && !tenantId) {
         console.log(
           "Syncing tenant from session to Redux:",
           session.microsoftTenantId,
@@ -51,7 +52,7 @@ export function useSessionSync() {
         dispatch(setTenantId(session.microsoftTenantId));
       }
     }
-  }, [session, status, appConfig.domain, appConfig.tenantId, dispatch]);
+  }, [session, status, domain, tenantId, dispatch]);
 
   return { session, status };
 }

--- a/hooks/use-step-execution.ts
+++ b/hooks/use-step-execution.ts
@@ -8,7 +8,9 @@ import { useAppDispatch, useAppSelector } from "./use-redux";
 
 export function useStepExecution() {
   const dispatch = useAppDispatch();
-  const appConfig = useAppSelector((state) => state.app);
+  const domain = useAppSelector((state) => state.app.domain);
+  const tenantId = useAppSelector((state) => state.app.tenantId);
+  const outputs = useAppSelector((state) => state.app.outputs);
 
   const executeStep = useCallback(
     async (stepId: StepId) => {
@@ -32,9 +34,9 @@ export function useStepExecution() {
 
       try {
         const context = {
-          domain: appConfig.domain!,
-          tenantId: appConfig.tenantId!,
-          outputs: appConfig.outputs,
+          domain: domain!,
+          tenantId: tenantId!,
+          outputs,
         };
 
         const result = await executeStepAction(stepId, context);
@@ -95,7 +97,7 @@ export function useStepExecution() {
         });
       }
     },
-    [dispatch, appConfig],
+    [dispatch, domain, tenantId, outputs],
   );
 
   return { executeStep };


### PR DESCRIPTION
## Summary
- optimize Redux subscriptions by selecting individual fields
- update hooks and components to use selective selectors
- keep lint/type-check/build green

## Testing
- `pnpm lint --fix`
- `pnpm type-check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684151fc0d8c8322ad6547ae9494b9f1