### PR TITLE
Fix build failure by adding validator types

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import type { ReactElement } from "react";
 import { useAppDispatch } from "@/hooks/use-redux";
 import { setError } from "@/lib/redux/slices/ui-state";
 
@@ -10,7 +11,7 @@ export default function RouteError({
 }: {
   error: Error & { digest?: string };
   reset: () => void;
-}): JSX.Element {
+}): ReactElement | null {
   const dispatch = useAppDispatch();
 
   useEffect(() => {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@types/node": "^22.15.29",
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.6",
+    "@types/validator": "^13.15.1",
     "concurrently": "^9.1.2",
     "cross-fetch": "^4.1.0",
     "eslint": "^9.28.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.6
         version: 19.1.6(@types/react@19.1.6)
+      '@types/validator':
+        specifier: ^13.15.1
+        version: 13.15.1
       concurrently:
         specifier: ^9.1.2
         version: 9.1.2
@@ -1494,6 +1497,9 @@ packages:
 
   '@types/uuid@8.3.4':
     resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
+
+  '@types/validator@13.15.1':
+    resolution: {integrity: sha512-9gG6ogYcoI2mCMLdcO0NYI0AYrbxIjv0MDmy/5Ywo6CpWWrqYayc+mmgxRsCgtcGJm9BSbXkMsmxGah1iGHAAQ==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -5548,6 +5554,8 @@ snapshots:
   '@types/use-sync-external-store@0.0.6': {}
 
   '@types/uuid@8.3.4': {}
+
+  '@types/validator@13.15.1': {}
 
   '@types/yargs-parser@21.0.3': {}
 


### PR DESCRIPTION
## Summary
- install `@types/validator`
- adjust error handling component typings

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684200c6db808322bb7a7ad7525889aa