### PR TITLE
Refactor admin role identifiers

### DIFF
--- a/app/(auth)/utils/admin-checks.ts
+++ b/app/(auth)/utils/admin-checks.ts
@@ -2,6 +2,7 @@ import { withRetry } from "@/lib/api/utils";
 import { Logger } from "@/lib/utils/logger";
 import type { JWT } from "next-auth/jwt";
 import { config } from "@/lib/config";
+import { MICROSOFT_GLOBAL_ADMIN_ROLE_TEMPLATE_ID } from "@/lib/constants/role-ids";
 
 export async function validateTokenPresence(token: JWT): Promise<{
   valid: boolean;
@@ -138,10 +139,10 @@ export async function checkMicrosoftAdmin(accessToken: string): Promise<boolean>
       data.value,
     );
 
-    const globalAdminRoleTemplateId = "62e90394-69f5-4237-9190-012177145e10";
     const isGlobalAdmin =
-      data.value?.some((role) => role.roleTemplateId === globalAdminRoleTemplateId) ??
-      false;
+      data.value?.some(
+        (role) => role.roleTemplateId === MICROSOFT_GLOBAL_ADMIN_ROLE_TEMPLATE_ID,
+      ) ?? false;
     Logger.debug(
       "[Auth]",
       `checkMicrosoftAdmin: Determined Global Admin: ${isGlobalAdmin}`,

--- a/lib/constants/role-ids.ts
+++ b/lib/constants/role-ids.ts
@@ -1,0 +1,8 @@
+/**
+ * Identifiers for key administrator roles across providers.
+ */
+export const GOOGLE_SUPER_ADMIN_ROLE_ID = "3";
+
+/** Global administrator role template ID for Microsoft Entra ID. */
+export const MICROSOFT_GLOBAL_ADMIN_ROLE_TEMPLATE_ID =
+  "62e90394-69f5-4237-9190-012177145e10";

--- a/lib/steps/google/grant-super-admin/check.ts
+++ b/lib/steps/google/grant-super-admin/check.ts
@@ -1,6 +1,9 @@
 import { OUTPUT_KEYS } from "@/lib/types";
 import { createStepCheck } from "../../utils/check-factory";
 import { googleApi } from "@/lib/api/google";
+import {
+  GOOGLE_SUPER_ADMIN_ROLE_ID,
+} from "@/lib/constants/role-ids";
 import { handleCheckError } from "../../utils/error-handling";
 import { getRequiredOutput } from "../../utils/get-output";
 
@@ -24,7 +27,9 @@ export const checkSuperAdmin = createStepCheck({
         return {
           completed: true,
           message: `Service account '${email}' has admin privileges.`,
-          outputs: { [OUTPUT_KEYS.SUPER_ADMIN_ROLE_ID]: "3" },
+          outputs: {
+            [OUTPUT_KEYS.SUPER_ADMIN_ROLE_ID]: GOOGLE_SUPER_ADMIN_ROLE_ID,
+          },
         };
       }
       const roles = await googleApi.roles.listAssignments(
@@ -32,12 +37,16 @@ export const checkSuperAdmin = createStepCheck({
         undefined,
         context.logger,
       );
-      const hasSuperAdmin = roles.some((r) => r.roleId === "3");
+      const hasSuperAdmin = roles.some(
+        (r) => r.roleId === GOOGLE_SUPER_ADMIN_ROLE_ID,
+      );
       return hasSuperAdmin
         ? {
             completed: true,
             message: `Service account has Super Admin role assigned.`,
-            outputs: { [OUTPUT_KEYS.SUPER_ADMIN_ROLE_ID]: "3" },
+            outputs: {
+              [OUTPUT_KEYS.SUPER_ADMIN_ROLE_ID]: GOOGLE_SUPER_ADMIN_ROLE_ID,
+            },
           }
         : {
             completed: false,

--- a/lib/steps/google/grant-super-admin/execute.ts
+++ b/lib/steps/google/grant-super-admin/execute.ts
@@ -1,4 +1,5 @@
 import { googleApi } from "@/lib/api/google";
+import { GOOGLE_SUPER_ADMIN_ROLE_ID } from "@/lib/constants/role-ids";
 
 import type { StepContext, StepExecutionResult } from "@/lib/types";
 import { OUTPUT_KEYS } from "@/lib/types";
@@ -54,7 +55,7 @@ export const executeGrantSuperAdmin = withExecutionHandling({
       return {
         success: true,
         message: `User '${email}' is already an admin.`,
-        outputs: { [OUTPUT_KEYS.SUPER_ADMIN_ROLE_ID]: "3" },
+        outputs: { [OUTPUT_KEYS.SUPER_ADMIN_ROLE_ID]: GOOGLE_SUPER_ADMIN_ROLE_ID },
         resourceUrl: portalUrls.google.users.details(email),
       };
     }
@@ -63,21 +64,26 @@ export const executeGrantSuperAdmin = withExecutionHandling({
       customerId,
       context.logger,
     );
-    if (roles.some((r) => r.roleId === "3")) {
+    if (roles.some((r) => r.roleId === GOOGLE_SUPER_ADMIN_ROLE_ID)) {
       return {
         success: true,
         message: `User '${email}' already has Super Admin role.`,
-        outputs: { [OUTPUT_KEYS.SUPER_ADMIN_ROLE_ID]: "3" },
+        outputs: { [OUTPUT_KEYS.SUPER_ADMIN_ROLE_ID]: GOOGLE_SUPER_ADMIN_ROLE_ID },
         resourceUrl: portalUrls.google.users.details(email),
       };
     }
 
-    await googleApi.roles.assign(email, "3", customerId, context.logger);
+    await googleApi.roles.assign(
+      email,
+      GOOGLE_SUPER_ADMIN_ROLE_ID,
+      customerId,
+      context.logger,
+    );
 
     return {
       success: true,
       message: `Super Admin role assigned to '${email}'.`,
-      outputs: { [OUTPUT_KEYS.SUPER_ADMIN_ROLE_ID]: "3" },
+      outputs: { [OUTPUT_KEYS.SUPER_ADMIN_ROLE_ID]: GOOGLE_SUPER_ADMIN_ROLE_ID },
       resourceUrl: portalUrls.google.users.details(email),
     };
   },


### PR DESCRIPTION
## Summary
- centralize admin role identifiers into constants
- refactor Google Super Admin check and execute logic to use the constant
- use the Microsoft global admin constant in auth utilities

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684202953ac88322991b035ad0c749ef