### PR TITLE
Add custom ESLint rules

### DIFF
--- a/app/(auth)/utils/admin-checks.ts
+++ b/app/(auth)/utils/admin-checks.ts
@@ -3,6 +3,10 @@ import { Logger } from "@/lib/utils/logger";
 import type { JWT } from "next-auth/jwt";
 import { config } from "@/lib/config";
 
+/** Microsoft Global Admin role template ID */
+export const MICROSOFT_GLOBAL_ADMIN_ROLE_ID =
+  "62e90394-69f5-4237-9190-012177145e10";
+
 export async function validateTokenPresence(token: JWT): Promise<{
   valid: boolean;
   missingTokens: ("google" | "microsoft")[];
@@ -138,9 +142,8 @@ export async function checkMicrosoftAdmin(accessToken: string): Promise<boolean>
       data.value,
     );
 
-    const globalAdminRoleTemplateId = "62e90394-69f5-4237-9190-012177145e10";
     const isGlobalAdmin =
-      data.value?.some((role) => role.roleTemplateId === globalAdminRoleTemplateId) ??
+      data.value?.some((role) => role.roleTemplateId === MICROSOFT_GLOBAL_ADMIN_ROLE_ID) ??
       false;
     Logger.debug(
       "[Auth]",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from "url";
 import tsdoc from "eslint-plugin-tsdoc";
 import security from "eslint-plugin-security";
 import sonar from "eslint-plugin-sonarjs";
+import custom from "./eslint/custom-rules.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -39,11 +40,24 @@ const eslintConfig = [
   {
     plugins: {
       tsdoc,
+      custom,
     },
     rules: {
       "react-redux/useSelector-prefer-selectors": "off",
       "tsdoc/syntax": "warn",
       "sonarjs/cognitive-complexity": ["warn", 20],
+      "custom/no-hardcoded-url": "error",
+      "custom/no-raw-fetch": "error",
+      "custom/no-console-log": "warn",
+      "custom/no-hardcoded-admin-id": "warn",
+      "no-magic-numbers": ["warn", { "ignore": [-1, 0, 1] }],
+    },
+  },
+  {
+    files: ["**/__tests__/**", "test/**"],
+    rules: {
+      "custom/no-console-log": "off",
+      "no-magic-numbers": "off",
     },
   },
   {

--- a/eslint/custom-rules.mjs
+++ b/eslint/custom-rules.mjs
@@ -1,0 +1,86 @@
+/* eslint-disable custom/no-hardcoded-admin-id */
+function isAllowedPath(filename, patterns) {
+  // eslint-disable-next-line security/detect-non-literal-regexp
+  return patterns.some((p) => new RegExp(p).test(filename));
+}
+
+const hardcodedUrlRule = {
+  meta: { type: 'problem', docs: { description: 'disallow hardcoded URLs' } },
+  create(context) {
+    return {
+      Literal(node) {
+        if (typeof node.value === 'string' && /https?:\/\//.test(node.value)) {
+          const filename = context.getFilename();
+          if (!isAllowedPath(filename, [
+            'url-builder',
+            'config',
+            'test',
+            'mock',
+            'api-enablement-error',
+          ])) {
+            context.report({ node, message: 'Do not hardcode URLs. Use url-builder or configuration.' });
+          }
+        }
+      },
+    };
+  },
+};
+
+const rawFetchRule = {
+  meta: { type: 'problem', docs: { description: 'enforce API helpers over fetch' } },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === 'Identifier' && node.callee.name === 'fetch') {
+          const filename = context.getFilename();
+          if (!isAllowedPath(filename, ['lib\/api', 'test', 'mock', 'token-refresh', 'utils', 'actions', 'api-enablement-error'])) {
+            context.report({ node, message: 'Use API helpers instead of raw fetch.' });
+          }
+        }
+      },
+    };
+  },
+};
+
+const consoleRule = {
+  meta: { type: 'problem', docs: { description: 'discourage console usage' } },
+  create(context) {
+    return {
+      MemberExpression(node) {
+        if (
+          node.object.type === 'Identifier' &&
+          node.object.name === 'console'
+        ) {
+          const filename = context.getFilename();
+          if (!isAllowedPath(filename, ['test'])) {
+            context.report({ node, message: 'Use Logger utilities instead of console.' });
+          }
+        }
+      },
+    };
+  },
+};
+
+const adminIdRule = {
+  meta: { type: 'problem', docs: { description: 'prevent hardcoded admin role ID' } },
+  create(context) {
+    return {
+      Literal(node) {
+        if (node.value === '62e90394-69f5-4237-9190-012177145e10') {
+          context.report({ node, message: 'Move Microsoft Global Admin ID to configuration.' });
+        }
+      },
+    };
+  },
+};
+
+const customRules = {
+  rules: {
+    'no-hardcoded-url': hardcodedUrlRule,
+    'no-raw-fetch': rawFetchRule,
+    'no-console-log': consoleRule,
+    'no-hardcoded-admin-id': adminIdRule,
+  },
+};
+
+export default customRules;


### PR DESCRIPTION
## Summary
- implement custom ESLint plugin for project conventions
- enforce plugin rules from eslint.config.mjs
- store Microsoft Global Admin role ID as a constant

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6842001bc794832292a4db1358880df7