### PR TITLE
Fix client env var access

### DIFF
--- a/__tests__/components/auth-error-env.test.tsx
+++ b/__tests__/components/auth-error-env.test.tsx
@@ -1,0 +1,11 @@
+import { expect } from "@jest/globals";
+
+/**
+ * Ensure auth error components can load without server-only environment variables.
+ */
+describe("auth error component environment", () => {
+  it("imports without throwing", () => {
+    expect(() => require("@/app/global-error")).not.toThrow();
+    expect(() => require("@/components/auth-error-boundary")).not.toThrow();
+  });
+});

--- a/__tests__/lib/api/google-client.test.ts
+++ b/__tests__/lib/api/google-client.test.ts
@@ -1,31 +1,36 @@
-jest.mock('@/lib/api/base/api-client', () => ({
-  createApiClient: jest.fn((cfg) => { global.cfg = cfg; return {}; })
-}))
+jest.mock("@/lib/api/base/api-client", () => ({
+  createApiClient: jest.fn((cfg) => {
+    global.cfg = cfg;
+    return {};
+  }),
+}));
 
-jest.mock('@/lib/api/auth-interceptor', () => ({ wrapAuthError: jest.fn() }))
+jest.mock("@/lib/api/auth-errors", () => ({ wrapAuthError: jest.fn() }));
 
-jest.mock('@/lib/api/api-enablement-error', () => ({
+jest.mock("@/lib/api/api-enablement-error", () => ({
   isAPIEnablementError: jest.fn(() => true),
-  createEnablementError: jest.fn((e) => new Error('enable ' + e.message)),
-}))
+  createEnablementError: jest.fn((e) => new Error("enable " + e.message)),
+}));
 
-import '@/lib/api/google/client'
-import { APIError } from '@/lib/api/utils'
-import { wrapAuthError } from '@/lib/api/auth-interceptor'
-import { createEnablementError } from '@/lib/api/api-enablement-error'
+import "@/lib/api/google/client";
+import { APIError } from "@/lib/api/utils";
+import { wrapAuthError } from "@/lib/api/auth-errors";
+import { createEnablementError } from "@/lib/api/api-enablement-error";
 
-const passed = (global as any).cfg
+const passed = (global as any).cfg;
 
-describe('googleApiClient handleProviderError', () => {
-  it('wraps auth and enable errors', () => {
-    const err = new APIError('bad', 401)
-    expect(() => passed.handleProviderError(err)).toThrowError()
-    expect(wrapAuthError).toHaveBeenCalled()
-  })
+describe("googleApiClient handleProviderError", () => {
+  it("wraps auth and enable errors", () => {
+    const err = new APIError("bad", 401);
+    expect(() => passed.handleProviderError(err)).toThrowError();
+    expect(wrapAuthError).toHaveBeenCalled();
+  });
 
-  it('handles enablement error', () => {
-    const err = new APIError('not enabled', 403)
-    try { passed.handleProviderError(err) } catch {}
-    expect(createEnablementError).toHaveBeenCalledWith(err)
-  })
-})
+  it("handles enablement error", () => {
+    const err = new APIError("not enabled", 403);
+    try {
+      passed.handleProviderError(err);
+    } catch {}
+    expect(createEnablementError).toHaveBeenCalledWith(err);
+  });
+});

--- a/__tests__/lib/api/microsoft-client.test.ts
+++ b/__tests__/lib/api/microsoft-client.test.ts
@@ -1,18 +1,23 @@
-import { APIError } from "@/lib/api/utils"
-import "@/lib/api/microsoft/client"
-import { wrapAuthError } from '@/lib/api/auth-interceptor'
+import { APIError } from "@/lib/api/utils";
+import "@/lib/api/microsoft/client";
+import { wrapAuthError } from "@/lib/api/auth-errors";
 
 // eslint-disable-next-line no-var
-var passedConfig: unknown
-jest.mock('@/lib/api/base/api-client', () => ({
-  createApiClient: jest.fn((cfg) => { passedConfig = cfg; return { get: jest.fn() } })
-}))
-jest.mock('@/lib/api/auth-interceptor', () => ({ wrapAuthError: jest.fn() }))
+var passedConfig: unknown;
+jest.mock("@/lib/api/base/api-client", () => ({
+  createApiClient: jest.fn((cfg) => {
+    passedConfig = cfg;
+    return { get: jest.fn() };
+  }),
+}));
+jest.mock("@/lib/api/auth-errors", () => ({ wrapAuthError: jest.fn() }));
 
-describe('microsoftApiClient', () => {
+describe("microsoftApiClient", () => {
   it("configures handleProviderError that wraps auth errors", () => {
-    const err = new APIError("bad", 401)
-    try { passedConfig.handleProviderError(err) } catch {}
-    expect(wrapAuthError).toHaveBeenCalledWith(err, "microsoft")
-  })
-})
+    const err = new APIError("bad", 401);
+    try {
+      passedConfig.handleProviderError(err);
+    } catch {}
+    expect(wrapAuthError).toHaveBeenCalledWith(err, "microsoft");
+  });
+});

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { AlertTriangleIcon, HomeIcon, RefreshCwIcon } from "lucide-react";
-import { isAuthenticationError } from "@/lib/api/auth-interceptor";
+import { isAuthenticationError } from "@/lib/api/auth-errors";
 
 export default function GlobalError({
   error,

--- a/components/auth-error-boundary.tsx
+++ b/components/auth-error-boundary.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { isAuthenticationError } from "@/lib/api/auth-interceptor";
+import { isAuthenticationError } from "@/lib/api/auth-errors";
 import { useErrorHandler } from "@/hooks/use-error-handler";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";

--- a/lib/api/auth-errors.ts
+++ b/lib/api/auth-errors.ts
@@ -1,0 +1,93 @@
+import { APIError } from "./utils";
+import { Provider, type ProviderType } from "@/lib/constants/enums";
+
+/**
+ * Error class thrown when API requests fail due to missing or expired
+ * authentication.
+ */
+export class AuthenticationError extends APIError {
+  constructor(
+    message: string,
+    public provider: ProviderType,
+    public originalError?: unknown
+  ) {
+    super(message, 401, "AUTH_EXPIRED");
+    this.name = "AuthenticationError";
+  }
+}
+
+/**
+ * Patterns used to detect authentication related messages from API responses.
+ */
+const AUTH_ERROR_PATTERNS = {
+  google: [
+    /invalid authentication credentials/i,
+    /OAuth 2 access token/i,
+    /login cookie or other valid authentication credential/i,
+    /Token has been expired or revoked/i,
+    /Request had insufficient authentication scopes/i,
+    /401 Unauthorized/i,
+  ],
+  microsoft: [
+    /InvalidAuthenticationToken/i,
+    /Access token validation failure/i,
+    /Token expired/i,
+    /CompactToken parsing failed/i,
+    /unauthorized_client/i,
+    /invalid_grant/i,
+  ],
+} as const;
+
+/**
+ * Determine whether the provided error indicates an authentication failure.
+ */
+export function isAuthenticationError(
+  error: unknown
+): error is AuthenticationError {
+  if (error instanceof AuthenticationError) return true;
+
+  if (error instanceof APIError) {
+    if (
+      error.status === 401 ||
+      error.code === "401" ||
+      Number(error.code) === 401
+    ) {
+      return true;
+    }
+
+    if (error.message) {
+      const errorMessage = error.message.toLowerCase();
+      return (
+        AUTH_ERROR_PATTERNS.google.some((pattern) => pattern.test(errorMessage)) ||
+        AUTH_ERROR_PATTERNS.microsoft.some((pattern) =>
+          pattern.test(errorMessage)
+        )
+      );
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Wrap an unknown error into an `AuthenticationError` for consistent handling.
+ */
+export function wrapAuthError(
+  error: unknown,
+  provider: ProviderType
+): AuthenticationError {
+  if (error instanceof APIError && error.status === 401) {
+    return new AuthenticationError(
+      `${provider === Provider.GOOGLE ? "Google Workspace" : "Microsoft"} authentication expired. Please sign in again.`,
+      provider,
+      error
+    );
+  }
+  return new AuthenticationError(
+    `Authentication failed for ${provider}. Please sign in again.`,
+    provider,
+    error
+  );
+}
+
+export { AUTH_ERROR_PATTERNS };

--- a/lib/api/google/client.ts
+++ b/lib/api/google/client.ts
@@ -1,6 +1,9 @@
 import { createApiClient } from "../base/api-client";
-import { wrapAuthError } from "../auth-interceptor";
-import { createEnablementError, isAPIEnablementError } from "../api-enablement-error";
+import { wrapAuthError } from "../auth-errors";
+import {
+  createEnablementError,
+  isAPIEnablementError,
+} from "../api-enablement-error";
 import { APIError } from "../utils";
 import { getGoogleToken } from "../../steps/utils/auth";
 
@@ -8,7 +11,11 @@ import { getGoogleToken } from "../../steps/utils/auth";
  * Normalize Google API errors into authentication or enablement errors.
  */
 function handleGoogleError(error: unknown): never {
-  if (error instanceof APIError && (error.status === 401 || error.message?.includes("invalid authentication credentials"))) {
+  if (
+    error instanceof APIError &&
+    (error.status === 401 ||
+      error.message?.includes("invalid authentication credentials"))
+  ) {
     throw wrapAuthError(error, "google");
   }
   if (error instanceof APIError && isAPIEnablementError(error)) {
@@ -21,7 +28,7 @@ function handleGoogleError(error: unknown): never {
  * API client instance preconfigured for Google Workspace APIs.
  */
 export const googleApiClient = createApiClient({
-  provider: 'google',
+  provider: "google",
   getToken: getGoogleToken,
   handleProviderError: handleGoogleError,
 });

--- a/lib/api/microsoft/client.ts
+++ b/lib/api/microsoft/client.ts
@@ -1,5 +1,5 @@
 import { createApiClient } from "../base/api-client";
-import { wrapAuthError } from "../auth-interceptor";
+import { wrapAuthError } from "../auth-errors";
 import { APIError } from "../utils";
 import { getMicrosoftToken } from "../../steps/utils/auth";
 
@@ -11,7 +11,7 @@ function handleMicrosoftError(error: unknown): never {
 }
 
 export const microsoftApiClient = createApiClient({
-  provider: 'microsoft',
+  provider: "microsoft",
   getToken: getMicrosoftToken,
   handleProviderError: handleMicrosoftError,
 });

--- a/lib/steps/utils/error-handling.ts
+++ b/lib/steps/utils/error-handling.ts
@@ -1,4 +1,4 @@
-import { isAuthenticationError } from "@/lib/api/auth-interceptor";
+import { isAuthenticationError } from "@/lib/api/auth-errors";
 import { APIError } from "@/lib/api/utils";
 import { serverLogger } from "@/lib/logging/server-logger";
 import { ErrorManager } from "@/lib/error-handling/error-manager";


### PR DESCRIPTION
## Summary
- avoid bundling server-only auth code on the client
- move authentication error helpers to new `lib/api/auth-errors.ts`
- re-export helpers from `auth-interceptor`
- update components to import from the new module
- adjust Microsoft and Google clients to import helpers from `auth-errors`
- update tests and add env check for auth error components

## Testing
- `pnpm lint` *(fails: unexpected any, etc.)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68420ea9e90c8322a40a31109b93c2e0