### PR TITLE
Refactor boundaries and providers

### DIFF
--- a/app/error-client.tsx
+++ b/app/error-client.tsx
@@ -1,0 +1,20 @@
+"use client";
+import type { ReactElement } from "react";
+
+/**
+ * Displays an error message for route-level errors.
+ */
+export function ErrorDisplay({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}): ReactElement {
+  return (
+    <div>
+      <h2>Error: {error.message}</h2>
+      <button onClick={reset}>Try again</button>
+    </div>
+  );
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,27 +1,17 @@
-"use client";
-
-import { useEffect } from "react";
-import type { ReactElement } from "react";
-import { useAppDispatch } from "@/hooks/use-redux";
-import { setError } from "@/lib/redux/slices/ui-state";
+import { ErrorDisplay } from "./error-client";
 import { Logger } from "@/lib/utils/logger";
+import type { ReactElement } from "react";
 
-export default function RouteError({
+/**
+ * Server boundary for route errors.
+ */
+export default function Error({
   error,
   reset,
 }: {
-  error: Error & { digest?: string };
+  error: Error;
   reset: () => void;
-}): ReactElement | null {
-  const dispatch = useAppDispatch();
-
-  useEffect(() => {
-    Logger.error('[RouteError]', 'Route error:', error);
-
-    const message = error.message || "An unexpected error occurred";
-    dispatch(setError({ message, details: { digest: error.digest } }));
-  }, [error, dispatch, reset]);
-
-  // Return null since error dialog will show
-  return null;
+}): ReactElement {
+  Logger.error('[RouteError]', 'Route error:', error);
+  return <ErrorDisplay error={error} reset={reset} />;
 }

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,66 +1,30 @@
 "use client";
+import type { ReactElement } from "react";
 
-import { useEffect } from "react";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { AlertTriangleIcon, HomeIcon, RefreshCwIcon } from "lucide-react";
-import { isAuthenticationError } from "@/lib/api/auth-interceptor";
-import { Logger } from "@/lib/utils/logger";
-
+/**
+ * Handles unhandled errors across the app.
+ */
 export default function GlobalError({
   error,
   reset,
 }: {
   error: Error & { digest?: string };
   reset: () => void;
-}) {
-  useEffect(() => {
-    Logger.error('[GlobalError]', 'Global error:', error);
-  }, [error]);
+}): ReactElement | null {
+  const isAuthError =
+    error.message?.includes("Authentication") ||
+    error.message?.includes("session expired");
 
-  if (isAuthenticationError(error)) {
-    if (typeof window !== "undefined") {
-      window.location.href = "/login?error=session_expired";
-    }
+  if (isAuthError && typeof window !== "undefined") {
+    window.location.href = "/login?error=session_expired";
     return null;
   }
 
   return (
     <html>
       <body>
-        <div className="min-h-screen flex items-center justify-center p-4 bg-slate-50 dark:bg-slate-900">
-          <Card className="max-w-md w-full">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2 text-red-600">
-                <AlertTriangleIcon className="h-5 w-5" />
-                Something went wrong
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <p className="text-sm text-muted-foreground">
-                {error.message || "An unexpected error occurred"}
-              </p>
-              {error.digest && (
-                <p className="text-xs text-muted-foreground font-mono">
-                  Error ID: {error.digest}
-                </p>
-              )}
-              <div className="flex gap-2">
-                <Button onClick={reset} className="flex-1">
-                  <RefreshCwIcon className="mr-2 h-4 w-4" />
-                  Try again
-                </Button>
-                <Button
-                  variant="outline"
-                  onClick={() => (window.location.href = "/")}
-                >
-                  <HomeIcon className="mr-2 h-4 w-4" />
-                  Go home
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-        </div>
+        <div>Error: {error.message}</div>
+        <button onClick={reset}>Reset</button>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,36 +2,34 @@ import { AutomationDashboard } from "@/components/dashboard";
 import { InitialConfigLoader } from "@/components/initial-config-loader";
 import { auth } from "@/lib/auth";
 import { redirect } from "next/navigation";
+
 /**
- * Server component that renders the automation dashboard once both providers
- * are authenticated.
+ * Server component rendering the automation dashboard.
  */
 export default async function Page() {
   const session = await auth();
 
   if (!session?.user) {
-    // Server component: do not render RouteGuard (client component) here
-    return null;
+    redirect("/login");
   }
 
-  // Redirect if either provider is missing.
   if (!session.hasGoogleAuth || !session.hasMicrosoftAuth) {
-    const queryParams = new URLSearchParams();
-    if (!session.hasGoogleAuth && !session.hasMicrosoftAuth)
-      queryParams.set("reason", "both_identities_missing");
-    else if (!session.hasGoogleAuth)
-      queryParams.set("reason", "google_auth_missing");
-    else queryParams.set("reason", "microsoft_auth_missing");
-    redirect(`/login?${queryParams.toString()}`);
+    redirect("/login");
   }
-
-  const domain = session.authFlowDomain ?? null;
-  const tenantId = session.microsoftTenantId ?? null;
 
   return (
     <>
-      <InitialConfigLoader domain={domain} tenantId={tenantId} />
-      <AutomationDashboard serverSession={session} />
+      <InitialConfigLoader
+        domain={session.authFlowDomain}
+        tenantId={session.microsoftTenantId}
+      />
+      <AutomationDashboard
+        initialSession={{
+          user: session.user,
+          hasGoogleAuth: session.hasGoogleAuth,
+          hasMicrosoftAuth: session.hasMicrosoftAuth,
+        }}
+      />
     </>
   );
 }

--- a/app/providers-client.tsx
+++ b/app/providers-client.tsx
@@ -1,0 +1,13 @@
+"use client";
+import { SessionProvider } from "next-auth/react";
+import { Provider as ReduxProvider } from "react-redux";
+import { store } from "@/lib/redux/store";
+
+/** Wraps the app with client-side providers. */
+export function ClientProviders({ children }: { children: React.ReactNode }) {
+  return (
+    <SessionProvider>
+      <ReduxProvider store={store}>{children}</ReduxProvider>
+    </SessionProvider>
+  );
+}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,20 +1,14 @@
-"use client";
-
-import { store } from "@/lib/redux/store";
-import { SessionProvider } from "next-auth/react";
-import { Provider as ReduxProvider } from "react-redux";
+import { ClientProviders } from "./providers-client";
 import { GlobalErrorModal } from "@/components/global-error-modal";
-/**
- * Wraps the app with NextAuth and Redux providers.
- */
 
+/**
+ * Wraps the app with global providers.
+ */
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <SessionProvider>
-      <ReduxProvider store={store}>
-        {children}
-        <GlobalErrorModal />
-      </ReduxProvider>
-    </SessionProvider>
+    <ClientProviders>
+      {children}
+      <GlobalErrorModal />
+    </ClientProviders>
   );
 }

--- a/components/dashboard/hooks/use-auto-checker.ts
+++ b/components/dashboard/hooks/use-auto-checker.ts
@@ -1,1 +1,0 @@
-export { useAutoCheck as useAutoChecker } from "@/hooks/use-auto-check";

--- a/components/dashboard/hooks/use-step-runner.ts
+++ b/components/dashboard/hooks/use-step-runner.ts
@@ -9,18 +9,19 @@ import { setError } from "@/lib/redux/slices/ui-state";
 import type { RootState } from "@/lib/redux/store";
 import type { StepId } from "@/lib/steps/step-refs";
 import type { StepCheckResult, StepContext } from "@/lib/types";
+import type { Session } from "next-auth";
 import { useCallback, useMemo } from "react";
 import { useStore } from "react-redux";
 import { Logger } from "@/lib/utils/logger";
 
-export function useStepRunner() {
+export function useStepRunner(initialSession?: Session) {
   const { session, status } = useSessionSync();
   const dispatch = useAppDispatch();
   const store = useStore<RootState>();
   const domain = useAppSelector((state: RootState) => state.app.domain);
   const tenantId = useAppSelector((state: RootState) => state.app.tenantId);
 
-  const currentSession = session;
+  const currentSession = session ?? initialSession;
   const canRunAutomation = useMemo(
     () =>
       !!(

--- a/components/dashboard/index.tsx
+++ b/components/dashboard/index.tsx
@@ -1,15 +1,14 @@
 "use client";
 import type { Session } from "next-auth";
 import React from "react";
-import { SessionGuard } from "./session-guard";
 import { ActionToolbar } from "./action-toolbar";
 import { ProgressSummary } from "./progress-summary";
 import { AutomationExecutor } from "./automation-executor";
 import { useStepRunner } from "./hooks/use-step-runner";
 import { useProgressPersistence } from "./hooks/use-progress-persistence";
-import { useAutoChecker } from "./hooks/use-auto-checker";
+import { useAutoCheck } from "@/hooks/use-auto-check";
 
-export function AutomationDashboard({ serverSession }: { serverSession: Session }) {
+export function AutomationDashboard({ initialSession }: { initialSession: Session }) {
   const {
     canRunAutomation,
     handleExecute,
@@ -17,33 +16,34 @@ export function AutomationDashboard({ serverSession }: { serverSession: Session 
     manualRefresh,
     isChecking,
     runAllPending,
-  } = useStepRunner();
+    session,
+    status,
+  } = useStepRunner(initialSession);
 
   useProgressPersistence();
-  useAutoChecker(executeCheck);
+  useAutoCheck(executeCheck);
+
+  const currentSession = session ?? initialSession;
+  const isLoading = status === "loading";
 
   return (
-    <SessionGuard serverSession={serverSession}>
-      {(currentSession, isLoading) => (
-        <div className="min-h-screen bg-slate-50 dark:bg-slate-900">
-          <main className="container mx-auto max-w-5xl space-y-8 p-4 py-8 md:p-8">
-            <header className="border-b pb-6">
-              <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-slate-50">
-                Google + Microsoft Integration
-              </h1>
-              <p className="mt-1 text-muted-foreground">Connect your directories in minutes</p>
-            </header>
-            <ActionToolbar session={currentSession} isLoadingSession={isLoading} />
-            <ProgressSummary
-              onRunAll={runAllPending}
-              onRefresh={manualRefresh}
-              isRefreshing={isChecking}
-              canRunAutomation={canRunAutomation}
-            />
-            <AutomationExecutor onExecuteStep={handleExecute} />
-          </main>
-        </div>
-      )}
-    </SessionGuard>
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-900">
+      <main className="container mx-auto max-w-5xl space-y-8 p-4 py-8 md:p-8">
+        <header className="border-b pb-6">
+          <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-slate-50">
+            Google + Microsoft Integration
+          </h1>
+          <p className="mt-1 text-muted-foreground">Connect your directories in minutes</p>
+        </header>
+        <ActionToolbar session={currentSession} isLoadingSession={isLoading} />
+        <ProgressSummary
+          onRunAll={runAllPending}
+          onRefresh={manualRefresh}
+          isRefreshing={isChecking}
+          canRunAutomation={canRunAutomation}
+        />
+        <AutomationExecutor onExecuteStep={handleExecute} />
+      </main>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- split error boundary logic so server and client parts stay separate
- move provider logic into a dedicated client component
- simplify `page.tsx` props
- drop unused auto-checker wrapper
- pass initial session to dashboard logic

## Testing
- `pnpm lint` *(fails: Cannot find module '/workspace/cepodyssey/eslint/custom-rules.mjs')*
- `pnpm test` *(fails: Could not locate module @/app/(auth)/auth)*

------
https://chatgpt.com/codex/tasks/task_e_6842254e7c90832288cd5066bac5bde5